### PR TITLE
Migrate the lmctl to use /api/v1

### DIFF
--- a/lmctl/cli/commands/targets/resource_managers.py
+++ b/lmctl/cli/commands/targets/resource_managers.py
@@ -34,7 +34,7 @@ class ResourceManagers(TNCOTarget):
         return {
             'name': name,
             'type': name, 
-            'url': 'https://my-rm.example.com/api/resource-manager'
+            'url': 'https://my-rm.example.com/api/v1/resource-manager'
         }
 
     @LmGet(output_formats=output_formats, help=f'''\

--- a/lmctl/client/api/assemblies.py
+++ b/lmctl/client/api/assemblies.py
@@ -10,7 +10,7 @@ from .tnco_api_base import TNCOAPI
 from lmctl.client.utils import build_relative_endpoint, read_response_location_header
 
 class AssembliesAPI(TNCOAPI):
-    topology_endpoint = 'api/topology/assemblies'
+    topology_endpoint = 'api/v1/topology/assemblies'
 
     def get(self, id: str) -> Dict:
         return self._get_json(
@@ -71,7 +71,7 @@ class AssembliesAPI(TNCOAPI):
         return self._intent_request_impl('adoptAssembly', intent_obj)   
 
     def intent_endpoint(self, intent_name: str) -> str:
-        return f'api/intent/{intent_name}'
+        return f'api/v1/intent/{intent_name}'
 
     def _intent_request_impl(self, intent_name: str, intent_obj: Union[Dict, 
                                                                         AdoptAssemblyIntent,

--- a/lmctl/client/api/behaviour_assembly_configurations.py
+++ b/lmctl/client/api/behaviour_assembly_configurations.py
@@ -2,7 +2,7 @@ from typing import List, Dict
 from .tnco_api_base import TNCOAPI
 
 class BehaviourAssemblyConfigurationsAPI(TNCOAPI):
-    endpoint = 'api/behaviour/assemblyConfigurations'
+    endpoint = 'api/v1/behaviour/assemblyConfigurations'
 
     def get(self, id: str) -> Dict:
         return self._get(id_value=id)

--- a/lmctl/client/api/behaviour_projects.py
+++ b/lmctl/client/api/behaviour_projects.py
@@ -2,7 +2,7 @@ from typing import List, Dict
 from .tnco_api_base import TNCOAPI
 
 class BehaviourProjectsAPI(TNCOAPI):
-    endpoint = 'api/behaviour/projects'
+    endpoint = 'api/v1/behaviour/projects'
 
     def all(self) -> List:
         return self._all()

--- a/lmctl/client/api/behaviour_scenario_executions.py
+++ b/lmctl/client/api/behaviour_scenario_executions.py
@@ -2,7 +2,7 @@ from typing import List, Dict
 from lmctl.client.client_request import TNCOClientRequest
 from .tnco_api_base import TNCOAPI
 class BehaviourScenarioExecutionsAPI(TNCOAPI):
-    endpoint = 'api/behaviour/executions'
+    endpoint = 'api/v1/behaviour/executions'
 
     def get(self, id: str, include_scenario: bool = None) -> Dict:
         query_params = {}

--- a/lmctl/client/api/behaviour_scenarios.py
+++ b/lmctl/client/api/behaviour_scenarios.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 from .tnco_api_base import TNCOAPI
 
 class BehaviourScenariosAPI(TNCOAPI):
-    endpoint = 'api/behaviour/scenarios'
+    endpoint = 'api/v1/behaviour/scenarios'
 
     def get(self, id: str) -> Dict:
         return self._get(id_value=id)

--- a/lmctl/client/api/deployment_locations.py
+++ b/lmctl/client/api/deployment_locations.py
@@ -2,7 +2,7 @@ from typing import List, Dict
 from .tnco_api_base import TNCOAPI
 
 class DeploymentLocationAPI(TNCOAPI):
-    endpoint = 'api/deploymentLocations'
+    endpoint = 'api/v1/deploymentLocations'
 
     def all(self) -> List:
         return self._all()

--- a/lmctl/client/api/descriptor_templates.py
+++ b/lmctl/client/api/descriptor_templates.py
@@ -3,7 +3,7 @@ from lmctl.client.client_request import TNCOClientRequest
 from .descriptors import DescriptorsAPI
 
 class DescriptorTemplatesAPI(DescriptorsAPI):
-    endpoint = 'api/catalog/descriptorTemplates'
+    endpoint = 'api/v1/catalog/descriptorTemplates'
 
     def __init__(self, base_client: 'TNCOClient'):
         if base_client.kami_address is not None:

--- a/lmctl/client/api/descriptors.py
+++ b/lmctl/client/api/descriptors.py
@@ -6,7 +6,7 @@ from lmctl.client.utils import build_relative_endpoint_from_data, build_relative
 
 
 class DescriptorsAPI(TNCOAPI):
-    endpoint = 'api/catalog/descriptors'
+    endpoint = 'api/v1/catalog/descriptors'
     id_attr = 'name'
 
     def create(self, descriptor: Dict):

--- a/lmctl/client/api/lifecycle_drivers.py
+++ b/lmctl/client/api/lifecycle_drivers.py
@@ -2,7 +2,7 @@ from typing import Dict
 from .tnco_api_base import TNCOAPI
 
 class LifecycleDriversAPI(TNCOAPI):
-    endpoint = 'api/resource-manager/lifecycle-drivers'
+    endpoint = 'api/v1/resource-manager/lifecycle-drivers'
 
     def get(self, id: str) -> Dict:
         return self._get(id_value=id)

--- a/lmctl/client/api/processes.py
+++ b/lmctl/client/api/processes.py
@@ -3,7 +3,7 @@ from .tnco_api_base import TNCOAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class ProcessesAPI(TNCOAPI):
-    endpoint = 'api/processes'
+    endpoint = 'api/v1/processes'
 
     def get(self, id: str, shallow: bool = None) -> Dict:
         query_params = {}

--- a/lmctl/client/api/resource_drivers.py
+++ b/lmctl/client/api/resource_drivers.py
@@ -2,7 +2,7 @@ from typing import Dict
 from .tnco_api_base import TNCOAPI
 
 class ResourceDriversAPI(TNCOAPI):
-    endpoint = 'api/resource-manager/resource-drivers'
+    endpoint = 'api/v1/resource-manager/resource-drivers'
 
     def get(self, id: str) -> Dict:
         return self._get(id_value=id)

--- a/lmctl/client/api/resource_managers.py
+++ b/lmctl/client/api/resource_managers.py
@@ -3,7 +3,7 @@ from .tnco_api_base import TNCOAPI
 from lmctl.client.utils import read_response_body_as_json
 
 class ResourceManagersAPI(TNCOAPI):
-    endpoint = 'api/resource-managers'
+    endpoint = 'api/v1/resource-managers'
     id_attr = 'name'
 
     def all(self) -> List:

--- a/lmctl/client/api/resource_packages.py
+++ b/lmctl/client/api/resource_packages.py
@@ -5,7 +5,7 @@ from .tnco_api_base import TNCOAPI
 from lmctl.client.utils import build_relative_endpoint
 
 class ResourcePackagesAPI(TNCOAPI):
-    endpoint = 'api/resource-manager/resource-packages'
+    endpoint = 'api/v1/resource-manager/resource-packages'
 
     def create(self, resource_pkg_path: Union[str,Path]) -> str:
         with open(resource_pkg_path, 'rb') as resource_pkg:

--- a/lmctl/client/api/shared_infrastructure_keys.py
+++ b/lmctl/client/api/shared_infrastructure_keys.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 from .tnco_api_base import TNCOAPI
 class SharedInfrastructureKeysAPI(TNCOAPI):
-    endpoint = 'api/resource-manager/infrastructure-keys/shared'
+    endpoint = 'api/v1/resource-manager/infrastructure-keys/shared'
     id_attr = 'name'
 
     def all(self, include_private_key: bool = None) -> List:

--- a/lmctl/client/api/vim_drivers.py
+++ b/lmctl/client/api/vim_drivers.py
@@ -1,7 +1,7 @@
 from typing import Dict
 from .tnco_api_base import TNCOAPI
 class VIMDriversAPI(TNCOAPI):
-    endpoint = 'api/resource-manager/vim-drivers'
+    endpoint = 'api/v1/resource-manager/vim-drivers'
 
     def get(self, driver_id: str) -> Dict:
         return self._get(id_value=driver_id)

--- a/lmctl/drivers/lm/behaviour.py
+++ b/lmctl/drivers/lm/behaviour.py
@@ -7,42 +7,42 @@ class LmBehaviourDriver(LmDriver):
     """
     Client for the CP4NA orchestration Behaviour APIs
     """
-
+    endpoint = '{0}/api/v1'
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __projects_api(self):
-        return '{0}/api/behaviour/projects'.format(self.lm_base)
+        return self.endpoint + '/behaviour/projects'.format(self.lm_base)
 
     def __project_api(self, project_id):
         return '{0}/{1}'.format(self.__projects_api(), project_id)
 
     def __assembly_configurations_in_project_api(self, project_id):
-        return '{0}/api/behaviour/assemblyConfigurations?projectId={1}'.format(self.lm_base, project_id)
+        return self.endpoint + '/behaviour/assemblyConfigurations?projectId={1}'.format(self.lm_base, project_id)
 
     def __assembly_configurations_api(self):
-        return '{0}/api/behaviour/assemblyConfigurations'.format(self.lm_base)
+        return self.endpoint + '/behaviour/assemblyConfigurations'.format(self.lm_base)
 
     def __assembly_configuration_api(self, template_id):
-        return '{0}/api/behaviour/assemblyConfigurations/{1}'.format(self.lm_base, template_id)
+        return self.endpoint + '/behaviour/assemblyConfigurations/{1}'.format(self.lm_base, template_id)
 
     def __scenarios_in_project_api(self, project_id):
-        return '{0}/api/behaviour/scenarios?projectId={1}'.format(self.lm_base, project_id)
+        return self.endpoint + '/behaviour/scenarios?projectId={1}'.format(self.lm_base, project_id)
 
     def __scenarios_api(self):
-        return '{0}/api/behaviour/scenarios'.format(self.lm_base)
+        return self.endpoint + '/behaviour/scenarios'.format(self.lm_base)
 
     def __scenario_api(self, scenario_id):
-        return '{0}/api/behaviour/scenarios/{1}'.format(self.lm_base, scenario_id)
+        return self.endpoint + '/behaviour/scenarios/{1}'.format(self.lm_base, scenario_id)
 
     def __scenario_execs_api(self, scenario_id):
-        return '{0}/api/behaviour/executions?scenarioId={1}'.format(self.lm_base, scenario_id)
+        return self.endpoint + '/behaviour/executions?scenarioId={1}'.format(self.lm_base, scenario_id)
 
     def __scenario_exec_api(self, exec_id):
-        return '{0}/api/behaviour/executions/{1}'.format(self.lm_base, exec_id)
+        return self.endpoint + '/behaviour/executions/{1}'.format(self.lm_base, exec_id)
 
     def __scenario_execution_api(self):
-        return '{0}/api/behaviour/executions'.format(self.lm_base)
+        return self.endpoint + '/behaviour/executions'.format(self.lm_base)
 
     def create_project(self, project):
         url = self.__projects_api()

--- a/lmctl/drivers/lm/deployment_locations.py
+++ b/lmctl/drivers/lm/deployment_locations.py
@@ -9,18 +9,19 @@ class LmDeploymentLocationDriver(LmDriver):
     """
     Client for CP4NA orchestration Deployment Location APIs
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __locations_api(self):
-        return '{0}/api/deploymentLocations'.format(self.lm_base)
+        return self.endpoint + '/deploymentLocations'.format(self.lm_base)
 
     def __location_by_name_api(self, location_name):
-        return '{0}/api/deploymentLocations?name={1}'.format(self.lm_base, location_name)
+        return self.endpoint + '/deploymentLocations?name={1}'.format(self.lm_base, location_name)
 
     def __location_by_id_api(self, location_id):
-        return '{0}/api/deploymentLocations/{1}'.format(self.lm_base, location_id)
+        return self.endpoint + '/deploymentLocations/{1}'.format(self.lm_base, location_id)
 
     def get_locations(self):
         url = self.__locations_api()

--- a/lmctl/drivers/lm/descriptor.py
+++ b/lmctl/drivers/lm/descriptor.py
@@ -10,12 +10,12 @@ class LmDescriptorDriver(LmDriver):
     """
     Client for CP4NA orchestration Descriptor APIs
     """
-
+    endpoint = '{0}/api/v1'
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def delete_descriptor(self, descriptor_name):
-        url = '{0}/api/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
+        url = self.endpoint + '/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
         headers = self._configure_access_headers()
         response = requests.delete(url, headers=headers, verify=False)
         if response.status_code == 404:
@@ -26,7 +26,7 @@ class LmDescriptorDriver(LmDriver):
             self._raise_unexpected_status_exception(response)
 
     def get_descriptor(self, descriptor_name):
-        url = '{0}/api/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
+        url = self.endpoint + '/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
         headers = {
             'Accept': 'application/yaml'
         }
@@ -40,7 +40,7 @@ class LmDescriptorDriver(LmDriver):
             self._raise_unexpected_status_exception(response)
 
     def create_descriptor(self, descriptor_content):
-        url = '{0}/api/catalog/descriptors'.format(self.lm_base)
+        url = self.endpoint + '/catalog/descriptors'.format(self.lm_base)
         headers = {
             'Content-Type': 'application/yaml'
         }
@@ -52,7 +52,7 @@ class LmDescriptorDriver(LmDriver):
             self._raise_unexpected_status_exception(response)
 
     def update_descriptor(self, descriptor_name, descriptor_content):
-        url = '{0}/api/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
+        url = self.endpoint + '/catalog/descriptors/{1}'.format(self.lm_base, descriptor_name)
         headers = {
             'Content-Type': 'application/yaml'
         }

--- a/lmctl/drivers/lm/descriptor_templates.py
+++ b/lmctl/drivers/lm/descriptor_templates.py
@@ -11,7 +11,7 @@ class LmDescriptorTemplatesDriver(LmDriver):
     Client for CP4NA orchestration Descriptor Template APIs
     """
 
-    TEMPLATES_API = 'api/catalog/descriptorTemplates'
+    TEMPLATES_API = 'api/v1/catalog/descriptorTemplates'
 
     def __init__(self, lm_base):
         super().__init__(lm_base)

--- a/lmctl/drivers/lm/etsipkgmgmtdriver.py
+++ b/lmctl/drivers/lm/etsipkgmgmtdriver.py
@@ -9,27 +9,28 @@ class EtsiPackageMgmtDriver(LmDriver):
     """
     Client for managing packages
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __packages_api(self):
-        return '{0}/api/etsi/vnfpkgm/v2/vnf_packages'.format(self.lm_base)
+        return self.endpoint + '/etsi/vnfpkgm/v2/vnf_packages'.format(self.lm_base)
 
     def __packages_api_by_id_api(self, package_id):
-        return '{0}/api/etsi/vnfpkgm/v2/vnf_packages/{1}'.format(self.lm_base, package_id)
+        return self.endpoint + '/etsi/vnfpkgm/v2/vnf_packages/{1}'.format(self.lm_base, package_id)
 
     def __packages_api_package_content(self, package_id):
-        return '{0}/api/etsi/vnfpkgm/v2/vnf_packages/{1}/package_content'.format(self.lm_base, package_id)
+        return self.endpoint + '/etsi/vnfpkgm/v2/vnf_packages/{1}/package_content'.format(self.lm_base, package_id)
 
     def __nsd_api(self):
-        return '{0}/api/etsi/nsd/v2/ns_descriptors'.format(self.lm_base)
+        return self.endpoint + '/etsi/nsd/v2/ns_descriptors'.format(self.lm_base)
 
     def __nsd_api_by_id(self, package_id):
-        return '{0}/api/etsi/nsd/v2/ns_descriptors/{1}'.format(self.lm_base, package_id)
+        return self.endpoint + '/etsi/nsd/v2/ns_descriptors/{1}'.format(self.lm_base, package_id)
 
     def __nsd_api_package_content(self, package_id):
-        return '{0}/api/etsi/nsd/v2/ns_descriptors/{1}/nsd_content'.format(self.lm_base, package_id)
+        return self.endpoint + '/etsi/nsd/v2/ns_descriptors/{1}/nsd_content'.format(self.lm_base, package_id)
 
     def __configure_headers(self, content_type='application/json'):
         headers = self._configure_access_headers()

--- a/lmctl/drivers/lm/infrastructure_keys.py
+++ b/lmctl/drivers/lm/infrastructure_keys.py
@@ -9,15 +9,16 @@ class LmInfrastructureKeysDriver(LmDriver):
     """
     Client for CP4NA orchestration Infrastructure Key APIs
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __infrastructure_keys_api(self):
-        return '{0}/api/resource-manager/infrastructure-keys/shared'.format(self.lm_base)
+        return self.endpoint + '/resource-manager/infrastructure-keys/shared'.format(self.lm_base)
 
     def __infrastructure_key_by_name_api(self, keyname):
-        return '{0}/api/resource-manager/infrastructure-keys/shared/{1}'.format(self.lm_base, keyname)
+        return self.endpoint + '/resource-manager/infrastructure-keys/shared/{1}'.format(self.lm_base, keyname)
 
     def get_infrastructure_keys(self):
         url = self.__infrastructure_keys_api()

--- a/lmctl/drivers/lm/lifecycledriver.py
+++ b/lmctl/drivers/lm/lifecycledriver.py
@@ -8,18 +8,19 @@ class LmLifecycleDriverMgmtDriver(LmDriver):
     """
     Client for managing lifecycle drivers
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __lifecycle_drivers_api(self):
-        return '{0}/api/resource-manager/lifecycle-drivers'.format(self.lm_base)
+        return self.endpoint + '/resource-manager/lifecycle-drivers'.format(self.lm_base)
 
     def __lifecycle_drivers_by_type_api(self, lifecycle_type):
-        return '{0}/api/resource-manager/lifecycle-drivers?type={1}'.format(self.lm_base, lifecycle_type)
+        return self.endpoint + '/resource-manager/lifecycle-drivers?type={1}'.format(self.lm_base, lifecycle_type)
 
     def __lifecycle_driver_by_id_api(self, driver_id):
-        return '{0}/api/resource-manager/lifecycle-drivers/{1}'.format(self.lm_base, driver_id)
+        return self.endpoint + '/resource-manager/lifecycle-drivers/{1}'.format(self.lm_base, driver_id)
 
     def add_lifecycle_driver(self, lifecycle_driver):
         url = self.__lifecycle_drivers_api()

--- a/lmctl/drivers/lm/onboarding.py
+++ b/lmctl/drivers/lm/onboarding.py
@@ -7,13 +7,14 @@ class LmOnboardRmDriver(LmDriver):
     """
     Client for CP4NA orchestration Resource Manager Onboarding APIs
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def update_rm(self, rm_data):
         rm_name = rm_data['name']
-        url = '{0}/api/resource-managers/{1}'.format(self.lm_base, rm_name)
+        url = self.endpoint + '/resource-managers/{1}'.format(self.lm_base, rm_name)
         headers = self._configure_access_headers()
         response = requests.put(url, json=rm_data, headers=headers, verify=False)
         if response.status_code == 404:
@@ -24,7 +25,7 @@ class LmOnboardRmDriver(LmDriver):
             self._raise_unexpected_status_exception(response)
 
     def get_rm_by_name(self, rm_name):
-        url = '{0}/api/resource-managers/{1}'.format(self.lm_base, rm_name)
+        url = self.endpoint + '/resource-managers/{1}'.format(self.lm_base, rm_name)
         headers = self._configure_access_headers()
         response = requests.get(url, headers=headers, verify=False)
         if response.status_code == 404:

--- a/lmctl/drivers/lm/resource_pkg.py
+++ b/lmctl/drivers/lm/resource_pkg.py
@@ -5,12 +5,13 @@ class LmResourcePkgDriver(LmDriver):
     """
     Client for CP4NA orchestration Resource Pkg APIs
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __packages_api(self):
-        return '{0}/api/resource-manager/resource-packages'.format(self.lm_base)
+        return self.endpoint + '/resource-manager/resource-packages'.format(self.lm_base)
 
     def __package_api(self, resource_type_name):
         return '{0}/{1}'.format(self.__packages_api(), resource_type_name)

--- a/lmctl/drivers/lm/resourcedriver.py
+++ b/lmctl/drivers/lm/resourcedriver.py
@@ -8,18 +8,19 @@ class LmResourceDriverMgmtDriver(LmDriver):
     """
     Client for managing Resource drivers
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __resource_drivers_api(self):
-        return '{0}/api/resource-manager/resource-drivers'.format(self.lm_base)
+        return self.endpoint + '/resource-manager/resource-drivers'.format(self.lm_base)
 
     def __resource_drivers_by_type_api(self, driver_type):
-        return '{0}/api/resource-manager/resource-drivers?type={1}'.format(self.lm_base, driver_type)
+        return self.endpoint + '/resource-manager/resource-drivers?type={1}'.format(self.lm_base, driver_type)
 
     def __resource_driver_by_id_api(self, driver_id):
-        return '{0}/api/resource-manager/resource-drivers/{1}'.format(self.lm_base, driver_id)
+        return self.endpoint + '/resource-manager/resource-drivers/{1}'.format(self.lm_base, driver_id)
 
     def add_resource_driver(self, resource_driver):
         url = self.__resource_drivers_api()

--- a/lmctl/drivers/lm/security.py
+++ b/lmctl/drivers/lm/security.py
@@ -14,7 +14,7 @@ class LmSecurityDriver(LmDriver):
     """
     Client for CP4NA orchestration Security APIs
     """
-
+    
     def __init__(self, lm_base):
         super().__init__(lm_base)
 

--- a/lmctl/drivers/lm/topology.py
+++ b/lmctl/drivers/lm/topology.py
@@ -7,12 +7,13 @@ class LmTopologyDriver(LmDriver):
     """
     Client for CP4NA orchestration Topology APIs
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def get_assembly_by_name(self, assembly_name):
-        url = '{0}/api/topology/assemblies/?name={1}'.format(self.lm_base, assembly_name)
+        url = self.endpoint + '/topology/assemblies/?name={1}'.format(self.lm_base, assembly_name)
         headers = self._configure_access_headers()
         response = requests.get(url, headers=headers, verify=False)
         if response.status_code == 200:
@@ -23,7 +24,7 @@ class LmTopologyDriver(LmDriver):
             self._raise_unexpected_status_exception(response)
 
     def delete_assembly(self, assembly_id):
-        url = '{0}/api/topology/assemblies/{1}'.format(self.lm_base, assembly_id)
+        url = self.endpoint + '/topology/assemblies/{1}'.format(self.lm_base, assembly_id)
         headers = self._configure_access_headers()
         response = requests.delete(url, headers=headers, verify=False)
         if response.status_code == 204:

--- a/lmctl/drivers/lm/vimdriver.py
+++ b/lmctl/drivers/lm/vimdriver.py
@@ -8,18 +8,19 @@ class LmVimDriverMgmtDriver(LmDriver):
     """
     Client for managing VIM Drivers
     """
-
+    endpoint = '{0}/api/v1'
+    
     def __init__(self, lm_base, lm_security_ctrl=None):
         super().__init__(lm_base, lm_security_ctrl)
 
     def __vim_drivers_api(self):
-        return '{0}/api/resource-manager/vim-drivers'.format(self.lm_base)
+        return self.endpoint + '/resource-manager/vim-drivers'.format(self.lm_base)
 
     def __vim_drivers_by_type_api(self, inf_type):
-        return '{0}/api/resource-manager/vim-drivers?infrastructureType={1}'.format(self.lm_base, inf_type)
+        return self.endpoint + '/resource-manager/vim-drivers?infrastructureType={1}'.format(self.lm_base, inf_type)
 
     def __vim_driver_by_id_api(self, driver_id):
-        return '{0}/api/resource-manager/vim-drivers/{1}'.format(self.lm_base, driver_id)
+        return self.endpoint + '/resource-manager/vim-drivers/{1}'.format(self.lm_base, driver_id)
 
     def add_vim_driver(self, vim_driver):
         url = self.__vim_drivers_api()

--- a/tests/integration/cli/test_resource_managers.py
+++ b/tests/integration/cli/test_resource_managers.py
@@ -17,13 +17,13 @@ class TestResourceManagers(CLIIntegrationTest):
         cls.test_case_props['resource_manager_A'] = {
             'name': tester.exec_prepended_name('rm-cmd-A'),
             'type': 'Brent',
-            'url': self.endpoint + '/resource-manager'
+            'url': cls.endpoint + '/resource-manager'
         }
         tester.default_client.resource_managers.create(cls.test_case_props['resource_manager_A'])
         cls.test_case_props['resource_manager_B'] = {
             'name': tester.exec_prepended_name('rm-cmd-B'),
             'type': 'Brent',
-            'url': self.endpoint + '/resource-manager'
+            'url': cls.endpoint + '/resource-manager'
         }
         tester.default_client.resource_managers.create(cls.test_case_props['resource_manager_B'])
         ## Add deployment location

--- a/tests/integration/cli/test_resource_managers.py
+++ b/tests/integration/cli/test_resource_managers.py
@@ -9,7 +9,7 @@ import json
 import time
 
 class TestResourceManagers(CLIIntegrationTest):
-
+    endpoint = 'https://brent:8291/api/v1'
     @classmethod
     def before_test_case(cls, tester):
         cls.test_case_props = {}
@@ -17,13 +17,13 @@ class TestResourceManagers(CLIIntegrationTest):
         cls.test_case_props['resource_manager_A'] = {
             'name': tester.exec_prepended_name('rm-cmd-A'),
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         tester.default_client.resource_managers.create(cls.test_case_props['resource_manager_A'])
         cls.test_case_props['resource_manager_B'] = {
             'name': tester.exec_prepended_name('rm-cmd-B'),
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         tester.default_client.resource_managers.create(cls.test_case_props['resource_manager_B'])
         ## Add deployment location
@@ -109,7 +109,7 @@ class TestResourceManagers(CLIIntegrationTest):
         resource_manager = {
             'name': rm_name,
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         yml_file = self.tester.create_yaml_file('rm-cmd-create-with.yaml', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -125,7 +125,7 @@ class TestResourceManagers(CLIIntegrationTest):
         resource_manager = {
             'name': rm_name,
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         json_file = self.tester.create_json_file('rm-cmd-create-with.json', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -139,7 +139,7 @@ class TestResourceManagers(CLIIntegrationTest):
     
     def test_create_with_set(self):
         rm_name = self.tester.exec_prepended_name('rm-cmd-create-with-set')
-        url = 'https://brent:8291/api/resource-manager'
+        url = self.endpoint + '/resource-manager'
         create_result = self.cli_runner.invoke(cli, [
             'create', 'resourcemanager', '-e', 'default', 
                         '--set', f'name={rm_name}', 
@@ -157,7 +157,7 @@ class TestResourceManagers(CLIIntegrationTest):
         resource_manager = {
             'name': rm_name,
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         yml_file = self.tester.create_yaml_file('rm-cmd-yaml-report.yaml', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -172,7 +172,7 @@ class TestResourceManagers(CLIIntegrationTest):
         resource_manager = {
             'name': rm_name,
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         yml_file = self.tester.create_yaml_file('rm-cmd-json-report.yaml', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -187,7 +187,7 @@ class TestResourceManagers(CLIIntegrationTest):
         resource_manager = {
             'name': rm_name,
             'type': 'Brent',
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         yml_file = self.tester.create_yaml_file('rm-cmd-create-yaml-print-report.yaml', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -227,7 +227,7 @@ class TestResourceManagers(CLIIntegrationTest):
     def test_update_with_set(self):
         rm_name = self.test_case_props['resource_manager_A']['name']
         update_result = self.cli_runner.invoke(cli, [
-            'update', 'resourcemanager', '-e', 'default', rm_name, '--set', 'url=https://brent:8291/api/resource-manager'
+            'update', 'resourcemanager', '-e', 'default', rm_name, '--set', 'url=https://brent:8291/api/v1/resource-manager'
             ])
         self.assert_output(update_result, f'Updated: {rm_name}')
         time.sleep(0.2)
@@ -290,7 +290,7 @@ class TestResourceManagers(CLIIntegrationTest):
         rm_name = self.tester.exec_prepended_name('rm-cmd-delete-with-yaml')
         resource_manager = {
             'name': rm_name,
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         yml_file = self.tester.create_yaml_file('rm-cmd-delete-with.yaml', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -315,7 +315,7 @@ class TestResourceManagers(CLIIntegrationTest):
         rm_name = self.tester.exec_prepended_name('rm-cmd-delete-with-json')
         resource_manager = {
             'name': rm_name,
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         json_file = self.tester.create_json_file('rm-cmd-delete-with.json', resource_manager)
         create_result = self.cli_runner.invoke(cli, [
@@ -340,7 +340,7 @@ class TestResourceManagers(CLIIntegrationTest):
         rm_name = self.tester.exec_prepended_name('rm-cmd-delete-with-json')
         resource_manager = {
             'name': rm_name,
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         json_file = self.tester.create_json_file('rm-cmd-delete-with.json', resource_manager)
         create_result = self.cli_runner.invoke(cli, [

--- a/tests/integration/client/test_resource_managers.py
+++ b/tests/integration/client/test_resource_managers.py
@@ -3,7 +3,8 @@ from lmctl.client import TNCOClientHttpError
 import os
 
 class TestResourceManagersAPI(IntegrationTest):
-
+    endpoint = 'https://brent:8291/api/v1'
+    
     @classmethod
     def before_test_case(cls, tester):
         cls.test_case_props = {}
@@ -40,7 +41,7 @@ class TestResourceManagersAPI(IntegrationTest):
     def test_crud(self):
         resource_manager = {
             'name': self.tester.exec_prepended_name('rm-crud'),
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         ## Create
         create_response = self.tester.default_client.resource_managers.create(resource_manager)
@@ -67,12 +68,12 @@ class TestResourceManagersAPI(IntegrationTest):
     def test_all(self):
         resource_managers_A = {
             'name': self.tester.exec_prepended_name('rm-all-A'),
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         self.tester.default_client.resource_managers.create(resource_managers_A)
         resource_managers_B = {
             'name': self.tester.exec_prepended_name('rm-all-B'),
-            'url': 'https://brent:8291/api/resource-manager'
+            'url': self.endpoint + '/resource-manager'
         }
         self.tester.default_client.resource_managers.create(resource_managers_B)
         all_response = self.tester.default_client.resource_managers.all()

--- a/tests/integration/test_properties.yaml
+++ b/tests/integration/test_properties.yaml
@@ -4,12 +4,12 @@ config:
       tnco: 
         address:
         secure: True
-        client_id: LmClient
+        client_id: Admin
         client_secret: 
 # Credentials used in Auth testing (set all 3 to valid credentials)
 auth_testing:
   client_credentials:
-    client_id: LmClient
+    client_id: Admin
     client_secret: 
   user_pass:
     client_id: NimrodClient
@@ -18,4 +18,6 @@ auth_testing:
     password: 
   legacy_user_pass:
     username: 
-    password: 
+    password:
+  token_auth:
+    token:  

--- a/tests/unit/client/api/test_assemblies.py
+++ b/tests/unit/client/api/test_assemblies.py
@@ -8,7 +8,7 @@ from lmctl.client.models import (CreateAssemblyIntent, UpgradeAssemblyIntent, Ch
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestAssembliesAPI(unittest.TestCase):
-
+    assemblyendpoint= 'api/v1'
     def setUp(self):
         self.mock_client = MagicMock()
         self.assemblies = AssembliesAPI(self.mock_client)
@@ -18,52 +18,52 @@ class TestAssembliesAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.assemblies.get('123')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/topology/assemblies/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.assemblyendpoint + '/topology/assemblies/123'))
     
     def test_get_by_name(self):
         mock_response = [{'id': '123', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.assemblies.get_by_name('Test')
         self.assertEqual(response, mock_response[0])
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/topology/assemblies', query_params={'name': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.assemblyendpoint + '/topology/assemblies', query_params={'name': 'Test'}))
    
     def test_get_topN(self):
         mock_response = [{'id': '123', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.assemblies.get_topN()
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/topology/assemblies'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.assemblyendpoint + '/topology/assemblies'))
     
     def test_all_with_name(self):
         mock_response = [{'id': '123', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.assemblies.all_with_name('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/topology/assemblies', query_params={'name': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.assemblyendpoint + '/topology/assemblies', query_params={'name': 'Test'}))
    
     def test_all_with_name_containing(self):
         mock_response = [{'id': '123', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.assemblies.all_with_name_containing('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/topology/assemblies', query_params={'nameContains': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.assemblyendpoint + '/topology/assemblies', query_params={'nameContains': 'Test'}))
 
     def test_intent(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'descriptorName': 'assembly::Test::1.0', 'assemblyName': 'Test', 'intendedState': 'Active'}
         response = self.assemblies.intent('createAssembly', intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/createAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/createAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_create(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + 'v1/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = CreateAssemblyIntent(descriptor_name='assembly::Test::1.0', assembly_name='Test', intended_state='Active') 
         response = self.assemblies.intent_create(intent)
         self.assertEqual(response, '123')
         self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', 
-                                                            endpoint='api/intent/createAssembly', 
+                                                            endpoint=self.assemblyendpoint + '/intent/createAssembly', 
                                                             headers={'Content-Type': 'application/json'}, 
                                                             body=json.dumps({
                                                                 'assemblyName': 'Test', 
@@ -73,15 +73,15 @@ class TestAssembliesAPI(unittest.TestCase):
                                                             })))
 
     def test_intent_create_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'descriptorName': 'assembly::Test::1.0', 'assemblyName': 'Test', 'intendedState': 'Active'}
         response = self.assemblies.intent_create(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/createAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/createAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_create_or_upgrade(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = CreateOrUpgradeAssemblyIntent(descriptor_name='assembly::Test::1.0', assembly_name='Test', intended_state='Active',
             tags={
@@ -95,7 +95,7 @@ class TestAssembliesAPI(unittest.TestCase):
         response = self.assemblies.intent_create_or_upgrade(intent)
         self.assertEqual(response, '123')
         self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', 
-                                                            endpoint='api/intent/createOrUpgradeAssembly', 
+                                                            endpoint=self.assemblyendpoint + '/intent/createOrUpgradeAssembly', 
                                                             headers={'Content-Type': 'application/json'}, 
                                                             body=json.dumps({
                                                                 'assemblyName': 'Test', 
@@ -112,13 +112,13 @@ class TestAssembliesAPI(unittest.TestCase):
                                                             })))
 
     def test_intent_upgrade(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = UpgradeAssemblyIntent(assembly_name='Test', descriptor_name='assembly::Test::1.0', intended_state='Active')
         response = self.assemblies.intent_upgrade(intent)
         self.assertEqual(response, '123')
         self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', 
-                                                            endpoint='api/intent/upgradeAssembly',
+                                                            endpoint=self.assemblyendpoint + '/intent/upgradeAssembly',
                                                             headers={'Content-Type': 'application/json'},  
                                                             body=json.dumps({
                                                                 'assemblyName': 'Test', 
@@ -128,101 +128,101 @@ class TestAssembliesAPI(unittest.TestCase):
                                                             })))
 
     def test_intent_upgrade_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'descriptorName': 'assembly::Test::1.0', 'assemblyName': 'Test', 'intendedState': 'Active'}
         response = self.assemblies.intent_upgrade(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/upgradeAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/upgradeAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_delete(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = DeleteAssemblyIntent(assembly_name='Test')
         response = self.assemblies.intent_delete(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/deleteAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/deleteAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test'})))
     
     def test_intent_delete_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test'}
         response = self.assemblies.intent_delete(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/deleteAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/deleteAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_change_state(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = ChangeAssemblyStateIntent(assembly_name='Test', intended_state='Active')
         response = self.assemblies.intent_change_state(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/changeAssemblyState', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'intendedState': 'Active'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/changeAssemblyState', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'intendedState': 'Active'})))
     
     def test_intent_change_state_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test', 'intendedState': 'Active'}
         response = self.assemblies.intent_change_state(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/changeAssemblyState', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/changeAssemblyState', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_scale_out(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = ScaleAssemblyIntent(assembly_name='Test', cluster_name='A')
         response = self.assemblies.intent_scale_out(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/scaleOutAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'clusterName': 'A'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/scaleOutAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'clusterName': 'A'})))
 
     def test_intent_scale_out_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test', 'clusterName': 'A'}
         response = self.assemblies.intent_scale_out(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/scaleOutAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/scaleOutAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_scale_in(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = ScaleAssemblyIntent(assembly_name='Test', cluster_name='A')
         response = self.assemblies.intent_scale_in(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/scaleInAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'clusterName': 'A'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/scaleInAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'clusterName': 'A'})))
 
     def test_intent_scale_in_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test', 'clusterName': 'A'}
         response = self.assemblies.intent_scale_in(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/scaleInAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/scaleInAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_heal(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = HealAssemblyIntent(assembly_name='Test', broken_component_name='A')
         response = self.assemblies.intent_heal(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/healAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'brokenComponentName': 'A'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/healAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyName': 'Test', 'brokenComponentName': 'A'})))
     
     def test_intent_heal_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test', 'brokenComponentName': 'A'}
         response = self.assemblies.intent_heal(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/healAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/healAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
     
     def test_intent_adopt(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = AdoptAssemblyIntent(assembly_name='Test', descriptor_name='assembly::Test::1.0', clusters={'B': 1})
         response = self.assemblies.intent_adopt(intent)
         self.assertEqual(response, '123')
         self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', 
-                                                        endpoint='api/intent/adoptAssembly', 
+                                                        endpoint=self.assemblyendpoint + '/intent/adoptAssembly', 
                                                         headers={'Content-Type': 'application/json'}, 
                                                         body=json.dumps({
                                                             'assemblyName': 'Test',
@@ -232,9 +232,9 @@ class TestAssembliesAPI(unittest.TestCase):
                                                         })))
     
     def test_intent_adopt_with_dict(self):
-        mock_response = MagicMock(headers={'Location': '/api/processes/123'})
+        mock_response = MagicMock(headers={'Location': self.assemblyendpoint + '/processes/123'})
         self.mock_client.make_request.return_value = mock_response
         intent = {'assemblyName': 'Test', 'descriptorName': 'assembly::Test::1.0', 'clusters': {'B': 1}}
         response = self.assemblies.intent_adopt(intent)
         self.assertEqual(response, '123')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/adoptAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.assemblyendpoint + '/intent/adoptAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))

--- a/tests/unit/client/api/test_behaviour_assembly_configurations.py
+++ b/tests/unit/client/api/test_behaviour_assembly_configurations.py
@@ -5,7 +5,9 @@ from lmctl.client.api import BehaviourAssemblyConfigurationsAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestBehaviourAssemblyConfigurationsAPI(unittest.TestCase):
-
+    
+    behaviourendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.behaviour_assembly_configurations = BehaviourAssemblyConfigurationsAPI(self.mock_client)
@@ -15,34 +17,34 @@ class TestBehaviourAssemblyConfigurationsAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_assembly_configurations.all_in_project('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/assemblyConfigurations', query_params={'projectId': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/assemblyConfigurations', query_params={'projectId': 'Test'}))
 
     def test_get(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_assembly_configurations.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/assemblyConfigurations/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/assemblyConfigurations/Test'))
 
     def test_create(self):
         test_obj = {'name': 'Test'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/assemblyConfigurations/123'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/assemblyConfigurations/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_assembly_configurations.create(test_obj)
         self.assertEqual(response, {'id': '123', 'name': 'Test'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/assemblyConfigurations', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/assemblyConfigurations', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         test_obj = {'id': '123', 'name': 'Test'}
         body = json.dumps(test_obj)
         response = self.behaviour_assembly_configurations.update(test_obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/behaviour/assemblyConfigurations/123', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.behaviourendpoint + '/behaviour/assemblyConfigurations/123', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.behaviour_assembly_configurations.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/behaviour/assemblyConfigurations/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.behaviourendpoint + '/behaviour/assemblyConfigurations/123'))
     
 

--- a/tests/unit/client/api/test_behaviour_projects.py
+++ b/tests/unit/client/api/test_behaviour_projects.py
@@ -5,7 +5,9 @@ from lmctl.client.api import BehaviourProjectsAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestBehaviourProjectsAPI(unittest.TestCase):
-
+    
+    behaviourendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.behaviour_projects = BehaviourProjectsAPI(self.mock_client)
@@ -15,34 +17,34 @@ class TestBehaviourProjectsAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = all_objects
         response = self.behaviour_projects.all()
         self.assertEqual(response, all_objects)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/projects'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/projects'))
 
     def test_get(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_projects.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/projects/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/projects/Test'))
 
     def test_create(self):
         test_obj = {'name': 'Test'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/projects/123'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/projects/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_projects.create(test_obj)
         self.assertEqual(response, {'id': '123', 'name': 'Test'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/projects', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/projects', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         test_obj = {'id': '123', 'name': 'Test'}
         body = json.dumps(test_obj)
         response = self.behaviour_projects.update(test_obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/behaviour/projects/123', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.behaviourendpoint + '/behaviour/projects/123', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.behaviour_projects.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/behaviour/projects/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.behaviourendpoint + '/behaviour/projects/123'))
     
 

--- a/tests/unit/client/api/test_behaviour_scenario_executions.py
+++ b/tests/unit/client/api/test_behaviour_scenario_executions.py
@@ -5,37 +5,39 @@ from lmctl.client.api import BehaviourScenarioExecutionsAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestBehaviourScenarioExecutionsAPI(unittest.TestCase):
-
+    
+    behaviourendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.behaviour_scenario_execs = BehaviourScenarioExecutionsAPI(self.mock_client)
 
     def test_execute_with_scenario_id(self):
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/executions/789'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/executions/789'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_scenario_execs.execute(scenario_id='Test')
         self.assertEqual(response, '789')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'scenarioId': 'Test'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'scenarioId': 'Test'})))
     
     def test_execute_with_scenario_id_and_request(self):
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/executions/789'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/executions/789'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_scenario_execs.execute(scenario_id='Test', execution_request={'assemblyId': 'assemblyA'})
         self.assertEqual(response, '789')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyId': 'assemblyA', 'scenarioId': 'Test'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyId': 'assemblyA', 'scenarioId': 'Test'})))
     
     def test_execute_with_request(self):
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/executions/789'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/executions/789'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_scenario_execs.execute(execution_request={'assemblyId': 'assemblyA', 'scenarioId': 'scenarioA'})
         self.assertEqual(response, '789')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyId': 'assemblyA', 'scenarioId': 'scenarioA'})))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/executions', headers={'Content-Type': 'application/json'}, body=json.dumps({'assemblyId': 'assemblyA', 'scenarioId': 'scenarioA'})))
 
     def test_cancel(self):
         mock_response = {'success': True}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.cancel('Test')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/executions/Test/cancel', headers={'Accept': 'application/json'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/executions/Test/cancel', headers={'Accept': 'application/json'}))
         self.assertEqual(response, mock_response)
 
     def test_get(self):
@@ -43,51 +45,51 @@ class TestBehaviourScenarioExecutionsAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions/Test'))
 
     def test_get_include_scenarios(self):
         mock_response = {'id': 'Test', 'name': 'Test', 'scenario': {}}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.get('Test', include_scenario=True)
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions/Test', query_params={'includeScenario': True}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions/Test', query_params={'includeScenario': True}))
 
     def test_delete(self):
         response = self.behaviour_scenario_execs.delete('Test')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/behaviour/executions/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.behaviourendpoint + '/behaviour/executions/Test'))
     
     def test_all_in_project(self):
         mock_response = [{'id': 'Test', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.all_in_project('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions', query_params={'projectId': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions', query_params={'projectId': 'Test'}))
     
     def test_all_of_scenario(self):
         mock_response = [{'id': 'Test', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.all_of_scenario('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions', query_params={'scenarioId': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions', query_params={'scenarioId': 'Test'}))
 
     def test_get_progress(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.get_progress('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions/Test/progress'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions/Test/progress'))
     
     def test_get_metrics(self):
         mock_response = [{'id': 'Test', 'name': 'TestMetric'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.get_metrics('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions/Test/metrics'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions/Test/metrics'))
     
     def test_get_metric(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenario_execs.get_metric('Test', 'TestMetric')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/executions/Test/metrics/TestMetric'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/executions/Test/metrics/TestMetric'))

--- a/tests/unit/client/api/test_behaviour_scenarios.py
+++ b/tests/unit/client/api/test_behaviour_scenarios.py
@@ -5,7 +5,9 @@ from lmctl.client.api import BehaviourScenariosAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestBehaviourScenariosAPI(unittest.TestCase):
-
+    
+    behaviourendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.behaviour_scenarios = BehaviourScenariosAPI(self.mock_client)
@@ -15,34 +17,34 @@ class TestBehaviourScenariosAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenarios.all_in_project('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/scenarios', query_params={'projectId': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/scenarios', query_params={'projectId': 'Test'}))
 
     def test_get(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.behaviour_scenarios.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/behaviour/scenarios/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.behaviourendpoint + '/behaviour/scenarios/Test'))
 
     def test_create(self):
         test_obj = {'name': 'Test'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/behaviour/scenarios/123'})
+        mock_response = MagicMock(headers={'Location': self.behaviourendpoint + '/behaviour/scenarios/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.behaviour_scenarios.create(test_obj)
         self.assertEqual(response, {'id': '123', 'name': 'Test'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/behaviour/scenarios', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.behaviourendpoint + '/behaviour/scenarios', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         test_obj = {'id': '123', 'name': 'Test'}
         body = json.dumps(test_obj)
         response = self.behaviour_scenarios.update(test_obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/behaviour/scenarios/123', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.behaviourendpoint + '/behaviour/scenarios/123', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.behaviour_scenarios.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/behaviour/scenarios/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.behaviourendpoint + '/behaviour/scenarios/123'))
     
 

--- a/tests/unit/client/api/test_deployment_locations.py
+++ b/tests/unit/client/api/test_deployment_locations.py
@@ -5,7 +5,9 @@ from lmctl.client.api import DeploymentLocationAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestDeploymentLocationAPI(unittest.TestCase):
-
+    
+    locationendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.deployment_locations = DeploymentLocationAPI(self.mock_client)
@@ -15,41 +17,41 @@ class TestDeploymentLocationAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = all_locations
         response = self.deployment_locations.all()
         self.assertEqual(response, all_locations)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/deploymentLocations'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.locationendpoint + '/deploymentLocations'))
 
     def test_all_with_name(self):
         mock_response = [{'id': 'Test', 'name': 'Test'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.deployment_locations.all_with_name('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/deploymentLocations', query_params={'name': 'Test'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.locationendpoint + '/deploymentLocations', query_params={'name': 'Test'}))
 
     def test_get(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.deployment_locations.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/deploymentLocations/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.locationendpoint + '/deploymentLocations/Test'))
 
     def test_create(self):
         location = {'name': 'Test'}
         body = json.dumps(location)
-        mock_response = MagicMock(headers={'Location': '/api/deploymentLocations/123'})
+        mock_response = MagicMock(headers={'Location': self.locationendpoint + '/deploymentLocations/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.deployment_locations.create(location)
         self.assertEqual(response, {'id': '123', 'name': 'Test'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/deploymentLocations', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.locationendpoint + '/deploymentLocations', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         location = {'id': '123', 'name': 'Test'}
         body = json.dumps(location)
         response = self.deployment_locations.update(location)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/deploymentLocations/123', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.locationendpoint + '/deploymentLocations/123', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.deployment_locations.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/deploymentLocations/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.locationendpoint + '/deploymentLocations/123'))
     
 

--- a/tests/unit/client/api/test_descriptor_templates.py
+++ b/tests/unit/client/api/test_descriptor_templates.py
@@ -5,7 +5,8 @@ from lmctl.client.api import DescriptorTemplatesAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestDescriptorTemplatesAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock(kami_address='http://kami.example.com')
         self.descriptor_templates = DescriptorTemplatesAPI(self.mock_client)
@@ -15,31 +16,31 @@ class TestDescriptorTemplatesAPI(unittest.TestCase):
         self.mock_client.make_request.return_value = MagicMock(text=mock_response)
         response = self.descriptor_templates.all()
         self.assertEqual(response, [{'name': 'assembly-template::Test::1.0'}])
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint='api/catalog/descriptorTemplates', headers={'Accept': 'application/yaml,application/json'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint=self.apiendpoint + '/catalog/descriptorTemplates', headers={'Accept': 'application/yaml,application/json'}, override_address='http://kami.example.com'))
 
     def test_get(self):
         mock_response = 'name: assembly-template::Test::1.0'
         self.mock_client.make_request.return_value = MagicMock(text=mock_response)
         response = self.descriptor_templates.get('assembly-template::Test::1.0')
         self.assertEqual(response, {'name': 'assembly-template::Test::1.0'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint='api/catalog/descriptorTemplates/assembly-template::Test::1.0', headers={'Accept': 'application/yaml,application/json'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint=self.apiendpoint + '/catalog/descriptorTemplates/assembly-template::Test::1.0', headers={'Accept': 'application/yaml,application/json'}, override_address='http://kami.example.com'))
 
     def test_create(self):
         obj = {'name': 'assembly-template::Test::1.0'}
         response = self.descriptor_templates.create(obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/catalog/descriptorTemplates', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/catalog/descriptorTemplates', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
 
     def test_update(self):
         obj = {'name': 'assembly-template::Test::1.0'}
         response = self.descriptor_templates.update(obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/catalog/descriptorTemplates/assembly-template::Test::1.0', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.apiendpoint + '/catalog/descriptorTemplates/assembly-template::Test::1.0', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
 
     def test_delete(self):
         response = self.descriptor_templates.delete('assembly-template::Test::1.0')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/catalog/descriptorTemplates/assembly-template::Test::1.0', override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/catalog/descriptorTemplates/assembly-template::Test::1.0', override_address='http://kami.example.com'))
     
     def test_render(self):
         mock_response = 'name: assembly::Result::1.0'
@@ -47,7 +48,7 @@ class TestDescriptorTemplatesAPI(unittest.TestCase):
         render_request = {'properties': {'propA': 'valueA'}}
         response = self.descriptor_templates.render('assembly-template::Test::1.0', render_request)
         self.assertEqual(response, {'name': 'assembly::Result::1.0'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/catalog/descriptorTemplates/assembly-template::Test::1.0/render', body=yaml.safe_dump(render_request), headers={'Accept': 'application/yaml', 'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/catalog/descriptorTemplates/assembly-template::Test::1.0/render', body=yaml.safe_dump(render_request), headers={'Accept': 'application/yaml', 'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
 
     def test_render_raw(self):
         mock_response = 'name: assembly::Result::1.0'
@@ -55,4 +56,4 @@ class TestDescriptorTemplatesAPI(unittest.TestCase):
         render_request = {'properties': {'propA': 'valueA'}}
         response = self.descriptor_templates.render_raw('assembly-template::Test::1.0', render_request)
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/catalog/descriptorTemplates/assembly-template::Test::1.0/render-raw', body=yaml.safe_dump(render_request), headers={'Accept': 'text/plain', 'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/catalog/descriptorTemplates/assembly-template::Test::1.0/render-raw', body=yaml.safe_dump(render_request), headers={'Accept': 'text/plain', 'Content-Type': 'application/yaml'}, override_address='http://kami.example.com'))

--- a/tests/unit/client/api/test_descriptors.py
+++ b/tests/unit/client/api/test_descriptors.py
@@ -5,7 +5,8 @@ from lmctl.client.api import DescriptorsAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestDescriptorsAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.descriptors = DescriptorsAPI(self.mock_client)
@@ -15,37 +16,37 @@ class TestDescriptorsAPI(unittest.TestCase):
         self.mock_client.make_request.return_value = MagicMock(text=mock_response)
         response = self.descriptors.all()
         self.assertEqual(response, [{'name': 'assembly::Test::1.0'}])
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint='api/catalog/descriptors', headers={'Accept': 'application/yaml,application/json'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint=self.apiendpoint + '/catalog/descriptors', headers={'Accept': 'application/yaml,application/json'}))
 
     def test_get(self):
         mock_response = 'name: assembly::Test::1.0'
         self.mock_client.make_request.return_value = MagicMock(text=mock_response)
         response = self.descriptors.get('assembly::Test::1.0')
         self.assertEqual(response, {'name': 'assembly::Test::1.0'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint='api/catalog/descriptors/assembly::Test::1.0', headers={'Accept': 'application/yaml,application/json'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint=self.apiendpoint + '/catalog/descriptors/assembly::Test::1.0', headers={'Accept': 'application/yaml,application/json'}))
 
     def test_get_effective(self):
         mock_response = 'name: assembly::Test::1.0'
         self.mock_client.make_request.return_value = MagicMock(text=mock_response)
         response = self.descriptors.get('assembly::Test::1.0', effective=True)
         self.assertEqual(response, {'name': 'assembly::Test::1.0'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint='api/catalog/descriptors/assembly::Test::1.0', query_params={'effective': True}, headers={'Accept': 'application/yaml,application/json'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='GET', endpoint=self.apiendpoint + '/catalog/descriptors/assembly::Test::1.0', query_params={'effective': True}, headers={'Accept': 'application/yaml,application/json'}))
 
     def test_create(self):
         obj = {'name': 'assembly::Test::1.0'}
         response = self.descriptors.create(obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/catalog/descriptors', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/catalog/descriptors', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}))
 
     def test_update(self):
         obj = {'name': 'assembly::Test::1.0'}
         response = self.descriptors.update(obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/catalog/descriptors/assembly::Test::1.0', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.apiendpoint + '/catalog/descriptors/assembly::Test::1.0', body=yaml.safe_dump(obj), headers={'Content-Type': 'application/yaml'}))
 
     def test_delete(self):
         response = self.descriptors.delete('assembly::Test::1.0')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/catalog/descriptors/assembly::Test::1.0'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/catalog/descriptors/assembly::Test::1.0'))
     
 

--- a/tests/unit/client/api/test_lifecycle_drivers.py
+++ b/tests/unit/client/api/test_lifecycle_drivers.py
@@ -5,7 +5,8 @@ from lmctl.client.api import LifecycleDriversAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestLifecycleDriversAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.resource_drivers = LifecycleDriversAPI(self.mock_client)
@@ -15,27 +16,27 @@ class TestLifecycleDriversAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/lifecycle-drivers/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/lifecycle-drivers/Test'))
     
     def test_get_by_type(self):
         mock_response = {'id': 'Test', 'type': 'Ansible'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get_by_type('Ansible')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/lifecycle-drivers', query_params={'type': 'Ansible'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/lifecycle-drivers', query_params={'type': 'Ansible'}))
 
     def test_create(self):
         test_obj = {'type': 'Ansible'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/resource-manager/lifecycle-drivers/123'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-manager/lifecycle-drivers/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.resource_drivers.create(test_obj)
         self.assertEqual(response, {'id': '123', 'type': 'Ansible'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-manager/lifecycle-drivers', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-manager/lifecycle-drivers', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.resource_drivers.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-manager/lifecycle-drivers/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-manager/lifecycle-drivers/123'))
     
 

--- a/tests/unit/client/api/test_processes.py
+++ b/tests/unit/client/api/test_processes.py
@@ -4,7 +4,8 @@ from lmctl.client.api import ProcessesAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestProcessesAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.processes = ProcessesAPI(self.mock_client)
@@ -14,18 +15,18 @@ class TestProcessesAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.processes.get('123')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/processes/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/processes/123'))
 
     def test_get_shallow(self):
         mock_response = {'id': '123'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.processes.get('123', shallow=True)
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/processes/123', query_params={'shallow': True}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/processes/123', query_params={'shallow': True}))
 
     def test_query(self):
         mock_response = [{'id': '123'}, {'id': '456'}]
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.processes.query(assemblyName='Abc', intentTypes='healAssembly')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/processes', query_params={'assemblyName': 'Abc', 'intentTypes': 'healAssembly'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/processes', query_params={'assemblyName': 'Abc', 'intentTypes': 'healAssembly'}))

--- a/tests/unit/client/api/test_resource_drivers.py
+++ b/tests/unit/client/api/test_resource_drivers.py
@@ -6,7 +6,8 @@ from lmctl.client.client_request import TNCOClientRequest
 
 
 class TestResourceDriversAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.resource_drivers = ResourceDriversAPI(self.mock_client)
@@ -16,27 +17,27 @@ class TestResourceDriversAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/resource-drivers/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/resource-drivers/Test'))
     
     def test_get_by_type(self):
         mock_response = {'id': 'Test', 'type': 'Kubernetes'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get_by_type('Kubernetes')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/resource-drivers', query_params={'type': 'Kubernetes'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/resource-drivers', query_params={'type': 'Kubernetes'}))
 
     def test_create(self):
         test_obj = {'type': 'Kubernetes'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/resource-manager/resource-drivers/123'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-manager/resource-drivers/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.resource_drivers.create(test_obj)
         self.assertEqual(response, {'id': '123', 'type': 'Kubernetes'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-manager/resource-drivers', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-manager/resource-drivers', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.resource_drivers.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-manager/resource-drivers/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-manager/resource-drivers/123'))
     
 

--- a/tests/unit/client/api/test_resource_managers.py
+++ b/tests/unit/client/api/test_resource_managers.py
@@ -5,7 +5,8 @@ from lmctl.client.api import ResourceManagersAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestResourceManagersAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.resource_managers = ResourceManagersAPI(self.mock_client)
@@ -15,25 +16,25 @@ class TestResourceManagersAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = all_objects
         response = self.resource_managers.all()
         self.assertEqual(response, all_objects)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-managers'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-managers'))
 
     def test_get(self):
         mock_response = {'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_managers.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-managers/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-managers/Test'))
 
     def test_create(self):
         test_obj = {'name': 'Test'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/resource-managers/123'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-managers/123'})
         mock_onboarding_report = {'resourceManagerOperation': 'ADD'}
         mock_response.json.return_value = mock_onboarding_report
         self.mock_client.make_request.return_value = mock_response
         response = self.resource_managers.create(test_obj)
         self.assertEqual(response, mock_onboarding_report)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-managers', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-managers', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         test_obj = {'name': 'Test'}
@@ -42,11 +43,11 @@ class TestResourceManagersAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_onboarding_report
         response = self.resource_managers.update(test_obj)
         self.assertEqual(response, mock_onboarding_report)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/resource-managers/Test', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.apiendpoint + '/resource-managers/Test', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.resource_managers.delete('Test')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-managers/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-managers/Test'))
     
 

--- a/tests/unit/client/api/test_resource_packages.py
+++ b/tests/unit/client/api/test_resource_packages.py
@@ -4,29 +4,30 @@ from lmctl.client.api import ResourcePackagesAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestResourcePackagesAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.resource_packages = ResourcePackagesAPI(self.mock_client)
 
     @patch("builtins.open", new_callable=mock_open, read_data="data")
     def test_create(self, mock_file):
-        mock_response = MagicMock(headers={'Location': '/api/resource-manager/resource-packages/123'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-manager/resource-packages/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.resource_packages.create('/some/test/file')
         self.assertEqual(response, '123')
         mock_file.assert_called_with('/some/test/file', 'rb')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-manager/resource-packages', files={'file': mock_file.return_value}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-manager/resource-packages', files={'file': mock_file.return_value}))
     
     @patch("builtins.open", new_callable=mock_open, read_data="data")
     def test_update(self, mock_file):
         response = self.resource_packages.update('Test', '/some/test/file')
         self.assertIsNone(response)
         mock_file.assert_called_with('/some/test/file', 'rb')
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/resource-manager/resource-packages/Test', files={'file': mock_file.return_value}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.apiendpoint + '/resource-manager/resource-packages/Test', files={'file': mock_file.return_value}))
    
     def test_delete(self):
         response = self.resource_packages.delete('Test')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-manager/resource-packages/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-manager/resource-packages/Test'))
     

--- a/tests/unit/client/api/test_shared_infrastructure_keys.py
+++ b/tests/unit/client/api/test_shared_infrastructure_keys.py
@@ -5,7 +5,8 @@ from lmctl.client.api import SharedInfrastructureKeysAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestSharedInfrastructureKeysAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.inf_keys = SharedInfrastructureKeysAPI(self.mock_client)
@@ -15,34 +16,34 @@ class TestSharedInfrastructureKeysAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = all_objects
         response = self.inf_keys.all()
         self.assertEqual(response, all_objects)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/infrastructure-keys/shared'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/infrastructure-keys/shared'))
 
     def test_get(self):
         mock_response = {'id': 'Test', 'name': 'Test'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.inf_keys.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/infrastructure-keys/shared/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/infrastructure-keys/shared/Test'))
 
     def test_create(self):
         test_obj = {'name': 'Test'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/resource-manager/infrastructure-keys/shared/Test'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-manager/infrastructure-keys/shared/Test'})
         self.mock_client.make_request.return_value = mock_response
         response = self.inf_keys.create(test_obj)
         self.assertEqual(response, {'name': 'Test'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-manager/infrastructure-keys/shared', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-manager/infrastructure-keys/shared', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_update(self):
         test_obj = {'id': '123', 'name': 'Test'}
         body = json.dumps(test_obj)
         response = self.inf_keys.update(test_obj)
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint='api/resource-manager/infrastructure-keys/shared/Test', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='PUT', endpoint=self.apiendpoint + '/resource-manager/infrastructure-keys/shared/Test', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.inf_keys.delete('Test')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-manager/infrastructure-keys/shared/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-manager/infrastructure-keys/shared/Test'))
     
 

--- a/tests/unit/client/api/test_vim_drivers.py
+++ b/tests/unit/client/api/test_vim_drivers.py
@@ -5,7 +5,8 @@ from lmctl.client.api import VIMDriversAPI
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestVIMDriversAPI(unittest.TestCase):
-
+    apiendpoint='api/v1'
+    
     def setUp(self):
         self.mock_client = MagicMock()
         self.resource_drivers = VIMDriversAPI(self.mock_client)
@@ -15,27 +16,27 @@ class TestVIMDriversAPI(unittest.TestCase):
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get('Test')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/vim-drivers/Test'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/vim-drivers/Test'))
     
     def test_get_by_type(self):
         mock_response = {'id': 'Test', 'type': 'Openstack'}
         self.mock_client.make_request.return_value.json.return_value = mock_response
         response = self.resource_drivers.get_by_type('Openstack')
         self.assertEqual(response, mock_response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint='api/resource-manager/vim-drivers', query_params={'type': 'Openstack'}))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest.build_request_for_json(method='GET', endpoint=self.apiendpoint + '/resource-manager/vim-drivers', query_params={'type': 'Openstack'}))
 
     def test_create(self):
         test_obj = {'type': 'Openstack'}
         body = json.dumps(test_obj)
-        mock_response = MagicMock(headers={'Location': '/api/resource-manager/vim-drivers/123'})
+        mock_response = MagicMock(headers={'Location': self.apiendpoint + '/resource-manager/vim-drivers/123'})
         self.mock_client.make_request.return_value = mock_response
         response = self.resource_drivers.create(test_obj)
         self.assertEqual(response, {'id': '123', 'type': 'Openstack'})
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/resource-manager/vim-drivers', headers={'Content-Type': 'application/json'}, body=body))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint=self.apiendpoint + '/resource-manager/vim-drivers', headers={'Content-Type': 'application/json'}, body=body))
 
     def test_delete(self):
         response = self.resource_drivers.delete('123')
         self.assertIsNone(response)
-        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint='api/resource-manager/vim-drivers/123'))
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='DELETE', endpoint=self.apiendpoint + '/resource-manager/vim-drivers/123'))
     
 


### PR DESCRIPTION
================================================
Build Result
================================================
  Gathering Version - OK
  Run Unit Tests - OK
  Build Wheel - OK
  Package Docs - OK


(env) [root@Mallanarhel81 lmctl]# lmctl --version
lmctl, version 3.1.1.dev0
(env) [root@Mallanarhel81 lmctl]# python3 -m unittest discover -s tests.unit
...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 675 tests in 9.561s

OK

(env) [root@Mallanarhel81 lmctl]# python3 -m unittest discover -s tests.integration
Generated execution name: sanguine-romario
.............................................................................................................................................sssssssssssssssssssssssssssss.........................s..............................F.......EE........................E..........ssss...EE.....
======================================================================
ERROR: setUpClass (tests.integration.cli.test_resource_drivers.TestResourceDrivers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 108, in make_request
    response.raise_for_status()
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/requests/models.py", line 953, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error:  for url: https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/integration_test_base.py", line 16, in setUpClass
    cls.before_test_case(IntegrationTest.tester)
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/cli/test_resource_drivers.py", line 18, in before_test_case
    'baseUri': 'http://ansible-lifecycle-driver:8292'
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/resource_drivers.py", line 11, in create
    return self._create(obj=driver)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 65, in _create
    id_value = self._exec_request(request, response_handler=read_response_location_header)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 28, in _exec_request
    response = self.base_client.make_request(request)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 110, in make_request
    raise TNCOClientHttpError(f'{request.method} request to {url} failed', e) from e
lmctl.client.exceptions.TNCOClientHttpError: POST request to https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers failed: status=400, message=Resource Driver LifecycleDriverDescriptor{id='null', type='vCloud', baseUri='http://ansible-lifecycle-driver:8292', certificate='null'} onboarding failed

======================================================================
ERROR: setUpClass (tests.integration.cli.test_resource_managers.TestResourceManagers)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/integration_test_base.py", line 16, in setUpClass
    cls.before_test_case(IntegrationTest.tester)
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/cli/test_resource_managers.py", line 20, in before_test_case
    'url': self.endpoint + '/resource-manager'
NameError: name 'self' is not defined

======================================================================
ERROR: test_token (tests.integration.client.test_auth.TestAuthenticationAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/client/test_auth.py", line 35, in test_token
    response = client.descriptors.all()
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/descriptors.py", line 47, in all
    return self._exec_request_and_parse_yaml(request)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 36, in _exec_request_and_parse_yaml
    return self._exec_request(request, response_handler=read_response_body_as_yaml)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 28, in _exec_request
    response = self.base_client.make_request(request)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 100, in make_request
    self._supplement_headers(headers=request_kwargs['headers'], inject_current_auth=request.inject_current_auth)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 74, in _supplement_headers
    self._add_auth_headers(headers=headers)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 65, in _add_auth_headers
    access_token = self.get_access_token()
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 58, in get_access_token
    self.auth_tracker.accept_auth_response(auth_response)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/auth_tracker.py", line 44, in accept_auth_response
    self._time_of_expiry = self._get_expires_time_from_jwt(self.current_access_token)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/auth_tracker.py", line 50, in _get_expires_time_from_jwt
    jwt_content = jwt.decode(token, options={'verify_signature': False}, algorithms=self.jwt_algorithms)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 104, in decode
    self._validate_claims(payload, merged_options, **kwargs)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 134, in _validate_claims
    self._validate_exp(payload, now, leeway)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 175, in _validate_exp
    raise ExpiredSignatureError('Signature has expired')
jwt.exceptions.ExpiredSignatureError: Signature has expired

======================================================================
ERROR: test_crd (tests.integration.client.test_resource_drivers.TestResourceDriversAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 108, in make_request
    response.raise_for_status()
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/requests/models.py", line 953, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error:  for url: https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/client/test_resource_drivers.py", line 12, in test_crd
    create_response = drivers_api.create(resource_driver)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/resource_drivers.py", line 11, in create
    return self._create(obj=driver)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 65, in _create
    id_value = self._exec_request(request, response_handler=read_response_location_header)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 28, in _exec_request
    response = self.base_client.make_request(request)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 110, in make_request
    raise TNCOClientHttpError(f'{request.method} request to {url} failed', e) from e
lmctl.client.exceptions.TNCOClientHttpError: POST request to https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers failed: status=400, message=Resource Driver LifecycleDriverDescriptor{id='null', type='sanguine-romario-crd-test', baseUri='http://ansible-lifecycle-driver:8292', certificate='null'} onboarding failed

======================================================================
ERROR: test_get_by_type (tests.integration.client.test_resource_drivers.TestResourceDriversAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 108, in make_request
    response.raise_for_status()
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/requests/models.py", line 953, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error:  for url: https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/client/test_resource_drivers.py", line 31, in test_get_by_type
    drivers_api.create(resource_driver)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/resource_drivers.py", line 11, in create
    return self._create(obj=driver)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 65, in _create
    id_value = self._exec_request(request, response_handler=read_response_location_header)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/api/tnco_api_base.py", line 28, in _exec_request
    response = self.base_client.make_request(request)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 110, in make_request
    raise TNCOClientHttpError(f'{request.method} request to {url} failed', e) from e
lmctl.client.exceptions.TNCOClientHttpError: POST request to https://cp4na-o-ishtar-lifecycle-manager.apps.ocp-vran-shail-dev.cp.fyre.ibm.com/api/v1/resource-manager/resource-drivers failed: status=400, message=Resource Driver LifecycleDriverDescriptor{id='null', type='sanguine-romario-get-by-type', baseUri='http://ansible-lifecycle-driver:8292', certificate='null'} onboarding failed

======================================================================
FAIL: test_login_with_token (tests.integration.cli.test_login.TestLogin)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/cli/test_login.py", line 162, in test_login_with_token
    self.assert_no_errors(result)
  File "/root/mallan/lmctl311dev/lmctl/tests/integration/cli/cli_test_base.py", line 37, in assert_no_errors
    self.fail(f'Unexpected exception thrown: \n---\n{exception_string}\n---{result.output}')
AssertionError: Unexpected exception thrown:
---
Traceback (most recent call last):
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/testing.py", line 329, in invoke
    cli.main(args=args or (), prog_name=prog_name, **extra)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/cli/commands/login.py", line 68, in login
    access_token = client.get_access_token()
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/client.py", line 58, in get_access_token
    self.auth_tracker.accept_auth_response(auth_response)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/auth_tracker.py", line 44, in accept_auth_response
    self._time_of_expiry = self._get_expires_time_from_jwt(self.current_access_token)
  File "/root/mallan/lmctl311dev/lmctl/lmctl/client/auth_tracker.py", line 50, in _get_expires_time_from_jwt
    jwt_content = jwt.decode(token, options={'verify_signature': False}, algorithms=self.jwt_algorithms)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 104, in decode
    self._validate_claims(payload, merged_options, **kwargs)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 134, in _validate_claims
    self._validate_exp(payload, now, leeway)
  File "/root/mallan/lmctl311dev/env/lib/python3.6/site-packages/jwt/api_jwt.py", line 175, in _validate_exp
    raise ExpiredSignatureError('Signature has expired')
jwt.exceptions.ExpiredSignatureError: Signature has expired

---

----------------------------------------------------------------------
Ran 283 tests in 2231.798s

FAILED (failures=1, errors=5, skipped=34)
