### PR TITLE
issue/121 - uplift dependency ranges

### DIFF
--- a/lmctl/environment/lmenv.py
+++ b/lmctl/environment/lmenv.py
@@ -94,6 +94,7 @@ class TNCOEnvironment:
     @root_validator(pre=True)
     @classmethod
     def normalize_addresses(cls, values):
+        auth_mode = values.get('auth_mode', None)
         address = values.get('address', None)
         if address is None:
             host = values.get('host', None)
@@ -108,7 +109,7 @@ class TNCOEnvironment:
 
         # Auth host
         auth_address = values.get('auth_address', None)
-        if auth_address is None:
+        if auth_address is None and (auth_mode is None or auth_mode.lower() != TOKEN_AUTH_MODE):
             auth_host = values.get('auth_host', None)
             auth_host = auth_host.strip() if auth_host is not None else None
             if not auth_host:

--- a/setup.py
+++ b/setup.py
@@ -23,16 +23,16 @@ setup(
     packages=find_namespace_packages(include=['lmctl*']),
     include_package_data=True,
     install_requires=[
-        'click>=7.1,<8.0',
+        'click>=7.1,<9.0',
         'requests>=2.23,<3.0',
         'ruamel.yaml>=0.16,<1.0',
-        'oyaml>=0.8,<1.0',
+        'oyaml>=0.8,<2.0',
         'tabulate>=0.8,<1.0',
-        'Jinja2==2.11.3',
+        'Jinja2>=2.11,<4.0',
         'PyYAML>=5.3.0,<6.0',
-        'pydantic==1.8.2',
+        'pydantic>=1.8,<2.0',
         'dataclasses>=0.6; python_version < "3.7"',
-        'pyjwt>=1.5.3,<2.0'
+        'pyjwt>=1.5.3,<3.0'
     ],
     entry_points='''
         [console_scripts]

--- a/tests/integration/cli/test_login.py
+++ b/tests/integration/cli/test_login.py
@@ -1,3 +1,4 @@
+from lmctl.client import zen_auth
 from .cli_test_base import CLIIntegrationTest
 from lmctl.cli.entry import cli
 
@@ -251,4 +252,4 @@ class TestLogin(CLIIntegrationTest):
         self.assertEqual(tnco.username, username)
         self.assertEqual(tnco.api_key, api_key)
         self.assertIsNone(tnco.token)
-        self.assertTrue(tnco.is_using_zen)
+        self.assertTrue(tnco.is_using_zen_auth)

--- a/tests/unit/environment/test_lmenv.py
+++ b/tests/unit/environment/test_lmenv.py
@@ -367,7 +367,7 @@ class TestLmSession(unittest.TestCase):
         session = LmSession(session_config)
         driver = session.descriptor_driver #Force LmSecurityCtrl to be created
         mock_client_builder = mock_client_builder_init.return_value 
-        mock_client_builder.address.assert_called_once_with('http://api:80')
+        mock_client_builder.address.assert_called_once_with(None)
         mock_client_builder.legacy_user_pass_auth.assert_not_called()
         mock_client_builder.user_pass_auth.assert_not_called()
         mock_client_builder.client_credentials_auth.assert_not_called()


### PR DESCRIPTION
Uplift dependency ranges to allow compatibility for use in CP4NA Site Planner.

This change also includes a fix to an integration test when using Zen.