### PR TITLE
Issue/135 - Support PyYAML 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'oyaml>=0.8,<2.0',
         'tabulate>=0.8,<1.0',
         'Jinja2>=2.11,<4.0',
-        'PyYAML>=5.3.0,<6.0',
+        'PyYAML>=5.3.0,<7.0',
         'pydantic>=1.8,<2.0',
         'dataclasses>=0.6; python_version < "3.7"',
         'pyjwt>=1.5.3,<3.0'


### PR DESCRIPTION
Closes #135 

Increasing the maximum bound of PyYAML dependency to allow `6.x` versions to be used. YAML is used heavily in `lmctl` and covered by existing tests, which all pass. 

The PyYAML v6.0 release notes do not include any breaking changes which would suggest `lmctl` cannot use it safely.