### PR TITLE
Add commands in LMCTL to retry, rollback and cancel intent process.

### DIFF
--- a/lmctl/cli/commands/actions.py
+++ b/lmctl/cli/commands/actions.py
@@ -52,11 +52,11 @@ def get():
 def heal():
     pass
 
-@action_group(help='Retry Assembly components')
+@action_group(help='Retry an Assembly components')
 def retry():
     pass
 
-@action_group(help='Rollback Assembly components')
+@action_group(help='Rollback an Assembly components')
 def rollback():
     pass
 

--- a/lmctl/cli/commands/actions.py
+++ b/lmctl/cli/commands/actions.py
@@ -52,6 +52,14 @@ def get():
 def heal():
     pass
 
+@action_group(help='Retry Assembly components')
+def retry():
+    pass
+
+@action_group(help='Rollback Assembly components')
+def rollback():
+    pass
+
 @action_group(help='Test connection to environments')
 def ping():
     pass

--- a/lmctl/cli/commands/processes.py
+++ b/lmctl/cli/commands/processes.py
@@ -90,21 +90,16 @@ For example:
 \n\nRetry process using {tnco_builder.display_name} ID: lmctl retry {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
 '''
 
-id_opt = Identifier(
-    param_name='process_id',
-    obj_attribute='brokenComponentId',
-    param_opts=['process-id']
-)
-
 @tnco_builder.make_general_command(
     group=retry,
     short_help=f'Request an intent to retry a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to retry a {tnco_builder.display_name}',
-    identifiers=[id_opt],
+    identifiers=[id_arg],
     help_suffix=retry_help_suffix,
-    pass_file_content=False
+    pass_file_content=False,
+    allow_file_input=False
 )
-@click.argument(*id_opt.param_opts,
+@click.argument(id_arg.param_name,
                required=True)
 @pass_io
 def retry_process(
@@ -128,11 +123,12 @@ For example:
     group=rollback,
     short_help=f'Request an intent to rollback a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to rollback a {tnco_builder.display_name}',
-    identifiers=[id_opt],
+    identifiers=[id_arg],
     help_suffix=rollback_help_suffix,
-    pass_file_content=False
+    pass_file_content=False,
+    allow_file_input=False
 )
-@click.argument(*id_opt.param_opts,
+@click.argument(id_arg.param_name,
                required=True)
 @pass_io
 def rollback_process(
@@ -155,11 +151,12 @@ For example:
     group=cancel,
     short_help=f'Request an intent to cancel a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to cancel a {tnco_builder.display_name}',
-    identifiers=[id_opt],
+    identifiers=[id_arg],
     help_suffix=cancel_help_suffix,
-    pass_file_content=False
+    pass_file_content=False,
+    allow_file_input=False
 )
-@click.argument(*id_opt.param_opts,
+@click.argument(id_arg.param_name,
                required=True)
 @pass_io
 def cancel_process(

--- a/lmctl/cli/commands/processes.py
+++ b/lmctl/cli/commands/processes.py
@@ -83,13 +83,11 @@ def get_process(
         query_params['limit'] = limit
     return api.query(**query_params)
 
-accepted_process_prefix = 'Accepted'
+accepted_process_prefix = 'Accepted -'
 
-help_suffix = f'''\
+retry_help_suffix = f'''\
 For example:
 \n\nRetry process using {tnco_builder.display_name} ID: lmctl retry {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
-\n\nCancel process using {tnco_builder.display_name} ID: lmctl cancel {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
-\n\nRollback process using {tnco_builder.display_name} ID: lmctl rollback {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
 '''
 
 id_opt = Identifier(
@@ -102,7 +100,8 @@ id_opt = Identifier(
     group=retry,
     short_help=f'Request an intent to retry a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to retry a {tnco_builder.display_name}',
-    help_suffix=help_suffix,
+    identifiers=[id_opt],
+    help_suffix=retry_help_suffix,
     pass_file_content=False
 )
 @click.argument(*id_opt.param_opts,
@@ -111,20 +110,26 @@ id_opt = Identifier(
 def retry_process(
         tnco_client: TNCOClient,
         io: IOController,
-        process_id : Identity,
+        identity: Identity,
         ):
 
     obj = {}
-    obj["processId"] = process_id
+    obj["processId"] = identity.value
     response = tnco_client.assemblies.intent_retry(obj)
-    io.print(f'{accepted_process_prefix} retrying process : {process_id}')
+    io.print(f'{accepted_process_prefix} Retry request for process: {identity.value}')
     return
+
+rollback_help_suffix = f'''\
+For example:
+\n\nRollback process using {tnco_builder.display_name} ID: lmctl rollback {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
+'''
 
 @tnco_builder.make_general_command(
     group=rollback,
     short_help=f'Request an intent to rollback a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to rollback a {tnco_builder.display_name}',
-    help_suffix=help_suffix,
+    identifiers=[id_opt],
+    help_suffix=rollback_help_suffix,
     pass_file_content=False
 )
 @click.argument(*id_opt.param_opts,
@@ -133,19 +138,25 @@ def retry_process(
 def rollback_process(
         tnco_client: TNCOClient,
         io: IOController,
-        process_id : Identity,
+        identity: Identity,
         ):
     obj = {}
-    obj["processId"] = process_id
+    obj["processId"] = identity.value
     response = tnco_client.assemblies.intent_rollback(obj)
-    io.print(f'{accepted_process_prefix} rolling back process : {process_id}')
+    io.print(f'{accepted_process_prefix} Rollback request for process: {identity.value}')
     return
+
+cancel_help_suffix = f'''\
+For example:
+\n\nCancel process using {tnco_builder.display_name} ID: lmctl cancel {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
+'''
 
 @tnco_builder.make_general_command(
     group=cancel,
     short_help=f'Request an intent to cancel a {tnco_builder.display_name}',
     help_prefix=f'Request an intent to cancel a {tnco_builder.display_name}',
-    help_suffix=help_suffix,
+    identifiers=[id_opt],
+    help_suffix=cancel_help_suffix,
     pass_file_content=False
 )
 @click.argument(*id_opt.param_opts,
@@ -154,11 +165,10 @@ def rollback_process(
 def cancel_process(
         tnco_client: TNCOClient,
         io: IOController,
-        process_id : Identity,
+        identity: Identity,
         ):
-
     obj = {}
-    obj["processId"] = process_id
+    obj["processId"] = identity.value
     response = tnco_client.assemblies.intent_cancel(obj)
-    io.print(f'{accepted_process_prefix} cancelling process : {process_id}')
+    io.print(f'{accepted_process_prefix} Cancel request for process: {identity.value}')
     return

--- a/lmctl/cli/commands/processes.py
+++ b/lmctl/cli/commands/processes.py
@@ -87,7 +87,9 @@ accepted_process_prefix = 'Accepted'
 
 help_suffix = f'''\
 For example:
-\n\nHeal using {tnco_builder.display_name} ID: lmctl retry {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
+\n\nRetry process using {tnco_builder.display_name} ID: lmctl retry {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
+\n\nCancel process using {tnco_builder.display_name} ID: lmctl cancel {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
+\n\nRollback process using {tnco_builder.display_name} ID: lmctl rollback {tnco_builder.singular} 6ad3327e-79df-464f-af48-3283f871584d
 '''
 
 id_opt = Identifier(

--- a/lmctl/client/api/assemblies.py
+++ b/lmctl/client/api/assemblies.py
@@ -10,6 +10,7 @@ from lmctl.client.client_request import TNCOClientRequest
 from .tnco_api_base import TNCOAPI
 from lmctl.client.utils import build_relative_endpoint, read_response_location_header
 
+INTENTS_WITHOUT_LOCATION_HEADER = ["retry", "rollback", "cancel"]
 
 class AssembliesAPI(TNCOAPI):
     topology_endpoint = 'api/topology/assemblies'
@@ -42,7 +43,10 @@ class AssembliesAPI(TNCOAPI):
                                                         DeleteAssemblyIntent, 
                                                         HealAssemblyIntent, 
                                                         ScaleAssemblyIntent,
-                                                        UpgradeAssemblyIntent]) -> str:
+                                                        UpgradeAssemblyIntent,
+                                                        RetryAssemblyIntent,
+                                                        CancelAssemblyIntent,
+                                                        RollbackAssemblyIntent]) -> str:
         return self._intent_request_impl(intent_name, intent_obj)
 
     def intent_create(self, intent_obj: Union[Dict, CreateAssemblyIntent]) -> str:
@@ -55,7 +59,6 @@ class AssembliesAPI(TNCOAPI):
         return self._intent_request_impl('createOrUpgradeAssembly', intent_obj)
 
     def intent_delete(self, intent_obj: Union[Dict, DeleteAssemblyIntent]) -> str:
-        print(intent_obj)
         return self._intent_request_impl('deleteAssembly', intent_obj)
 
     def intent_change_state(self, intent_obj: Union[Dict, ChangeAssemblyStateIntent]) -> str:
@@ -93,13 +96,12 @@ class AssembliesAPI(TNCOAPI):
                                                                         HealAssemblyIntent, 
                                                                         ScaleAssemblyIntent,
                                                                         UpgradeAssemblyIntent]) -> str:
-        process_intents = ["retry", "rollback", "cancel"]
         endpoint = self.intent_endpoint(intent_name)
         if isinstance(intent_obj, Intent):
             intent_obj_data = intent_obj.to_dict()
         else:
             intent_obj_data = intent_obj
         request = TNCOClientRequest(method='POST', endpoint=endpoint).add_json_body(intent_obj_data)
-        if intent_name in process_intents:
+        if intent_name in INTENTS_WITHOUT_LOCATION_HEADER:
             return self._exec_request(request)
         return self._exec_request_and_get_location_header(request)

--- a/lmctl/client/api/assemblies.py
+++ b/lmctl/client/api/assemblies.py
@@ -67,6 +67,15 @@ class AssembliesAPI(TNCOAPI):
     def intent_heal(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
         return self._intent_request_impl('healAssembly', intent_obj)
 
+    def intent_retry(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+        return self._intent_request_impl('retry', intent_obj)
+
+    def intent_rollback(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+        return self._intent_request_impl('rollback', intent_obj)
+
+    def intent_cancel(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+        return self._intent_request_impl('cancel', intent_obj)
+
     def intent_adopt(self, intent_obj: Union[Dict, AdoptAssemblyIntent]) -> str:
         return self._intent_request_impl('adoptAssembly', intent_obj)   
 
@@ -81,10 +90,13 @@ class AssembliesAPI(TNCOAPI):
                                                                         HealAssemblyIntent, 
                                                                         ScaleAssemblyIntent,
                                                                         UpgradeAssemblyIntent]) -> str:
+        process_intents = ["retry", "rollback", "cancel"]
         endpoint = self.intent_endpoint(intent_name)
         if isinstance(intent_obj, Intent):
             intent_obj_data = intent_obj.to_dict()
         else:
             intent_obj_data = intent_obj
         request = TNCOClientRequest(method='POST', endpoint=endpoint).add_json_body(intent_obj_data)
+        if intent_name in process_intents:
+            return self._exec_request(request)
         return self._exec_request_and_get_location_header(request)

--- a/lmctl/client/api/assemblies.py
+++ b/lmctl/client/api/assemblies.py
@@ -3,11 +3,13 @@ from typing import List, Dict, Union
 from lmctl.client.exceptions import TNCOClientError
 from lmctl.client.models import (CreateAssemblyIntent, UpgradeAssemblyIntent, ChangeAssemblyStateIntent, 
                                     DeleteAssemblyIntent, ScaleAssemblyIntent, HealAssemblyIntent,
-                                    AdoptAssemblyIntent, CreateOrUpgradeAssemblyIntent, Intent)
+                                    AdoptAssemblyIntent, CreateOrUpgradeAssemblyIntent,
+                                    RollbackAssemblyIntent, CancelAssemblyIntent, RetryAssemblyIntent, Intent)
 
 from lmctl.client.client_request import TNCOClientRequest
 from .tnco_api_base import TNCOAPI
 from lmctl.client.utils import build_relative_endpoint, read_response_location_header
+
 
 class AssembliesAPI(TNCOAPI):
     topology_endpoint = 'api/topology/assemblies'
@@ -53,6 +55,7 @@ class AssembliesAPI(TNCOAPI):
         return self._intent_request_impl('createOrUpgradeAssembly', intent_obj)
 
     def intent_delete(self, intent_obj: Union[Dict, DeleteAssemblyIntent]) -> str:
+        print(intent_obj)
         return self._intent_request_impl('deleteAssembly', intent_obj)
 
     def intent_change_state(self, intent_obj: Union[Dict, ChangeAssemblyStateIntent]) -> str:
@@ -67,13 +70,13 @@ class AssembliesAPI(TNCOAPI):
     def intent_heal(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
         return self._intent_request_impl('healAssembly', intent_obj)
 
-    def intent_retry(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+    def intent_retry(self, intent_obj: Union[Dict, RetryAssemblyIntent]) -> str:
         return self._intent_request_impl('retry', intent_obj)
 
-    def intent_rollback(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+    def intent_rollback(self, intent_obj: Union[Dict, RollbackAssemblyIntent]) -> str:
         return self._intent_request_impl('rollback', intent_obj)
 
-    def intent_cancel(self, intent_obj: Union[Dict, HealAssemblyIntent]) -> str:
+    def intent_cancel(self, intent_obj: Union[Dict, CancelAssemblyIntent]) -> str:
         return self._intent_request_impl('cancel', intent_obj)
 
     def intent_adopt(self, intent_obj: Union[Dict, AdoptAssemblyIntent]) -> str:

--- a/lmctl/client/models/__init__.py
+++ b/lmctl/client/models/__init__.py
@@ -1,3 +1,4 @@
 from .intents import (Intent, ExistingAssemblyIntent, CreateAssemblyIntent, 
                         ChangeAssemblyStateIntent, DeleteAssemblyIntent, HealAssemblyIntent,
-                        ScaleAssemblyIntent, UpgradeAssemblyIntent, CreateOrUpgradeAssemblyIntent, AdoptAssemblyIntent)
+                        ScaleAssemblyIntent, UpgradeAssemblyIntent, CreateOrUpgradeAssemblyIntent, AdoptAssemblyIntent,
+                        CancelAssemblyIntent, RetryAssemblyIntent, RollbackAssemblyIntent)

--- a/lmctl/client/models/intents.py
+++ b/lmctl/client/models/intents.py
@@ -97,7 +97,7 @@ class DeleteAssemblyIntent(ExistingAssemblyIntent):
 class RetryAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
-        if process_id == None or process_id == "":
+        if process_id == None or len(process_id.strip()) == 0:
             raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 
@@ -114,7 +114,7 @@ class RetryAssemblyIntent(Intent):
 class RollbackAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
-        if process_id == None or process_id == "":
+        if process_id == None or len(process_id.strip()) == 0:
             raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 
@@ -131,7 +131,7 @@ class RollbackAssemblyIntent(Intent):
 class CancelAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
-        if process_id == None or process_id == "":
+        if process_id == None or len(process_id.strip()) == 0:
             raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 

--- a/lmctl/client/models/intents.py
+++ b/lmctl/client/models/intents.py
@@ -97,6 +97,8 @@ class DeleteAssemblyIntent(ExistingAssemblyIntent):
 class RetryAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
+        if process_id == None or process_id == "":
+            raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 
     def set_process_id(self, process_id : str):
@@ -112,6 +114,8 @@ class RetryAssemblyIntent(Intent):
 class RollbackAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
+        if process_id == None or process_id == "":
+            raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 
     def set_process_id(self, process_id : str):
@@ -127,9 +131,12 @@ class RollbackAssemblyIntent(Intent):
 class CancelAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
+        if process_id == None or process_id == "":
+            raise ValueError("Process id can not be None or empty")
         self.process_id = process_id
 
     def set_process_id(self, process_id : str):
+        print("Not found")
         self.process_id = process_id
         return self
 

--- a/lmctl/client/models/intents.py
+++ b/lmctl/client/models/intents.py
@@ -94,10 +94,14 @@ class DeleteAssemblyIntent(ExistingAssemblyIntent):
         return (isinstance(other, DeleteAssemblyIntent) and self.assembly_name==other.assembly_name
             and self.assembly_id==other.assembly_id)
 
-class RetryAssemblyIntent():
+class RetryAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
         self.process_id = process_id
+
+    def set_process_id(self, process_id : str):
+        self.process_id = process_id
+        return self
 
     def to_dict(self) -> Dict:
         obj = {}
@@ -105,10 +109,14 @@ class RetryAssemblyIntent():
             obj['process_id'] = self.process_id
         return obj
 
-class RollbackAssemblyIntent():
+class RollbackAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
         self.process_id = process_id
+
+    def set_process_id(self, process_id : str):
+        self.process_id = process_id
+        return self
 
     def to_dict(self) -> Dict:
         obj = {}
@@ -116,10 +124,14 @@ class RollbackAssemblyIntent():
             obj['process_id'] = self.process_id
         return obj
 
-class CancelAssemblyIntent():
+class CancelAssemblyIntent(Intent):
 
     def __init__(self, process_id: str = None):
         self.process_id = process_id
+
+    def set_process_id(self, process_id : str):
+        self.process_id = process_id
+        return self
 
     def to_dict(self) -> Dict:
         obj = {}

--- a/lmctl/client/models/intents.py
+++ b/lmctl/client/models/intents.py
@@ -94,6 +94,33 @@ class DeleteAssemblyIntent(ExistingAssemblyIntent):
         return (isinstance(other, DeleteAssemblyIntent) and self.assembly_name==other.assembly_name
             and self.assembly_id==other.assembly_id)
 
+class RetryAssemblyIntent(ExistingAssemblyIntent):
+
+    def __init__(self, assembly_id: str = None):
+        super().__init__(assembly_id=assembly_id)
+
+    def to_dict(self) -> Dict:
+        obj = super().to_dict()
+        return obj
+
+class RollbackAssemblyIntent(ExistingAssemblyIntent):
+
+    def __init__(self, assembly_id: str = None):
+        super().__init__(assembly_id=assembly_id)
+
+    def to_dict(self) -> Dict:
+        obj = super().to_dict()
+        return obj
+
+class CancelAssemblyIntent(ExistingAssemblyIntent):
+
+    def __init__(self, assembly_id: str = None):
+        super().__init__(assembly_id=assembly_id)
+
+    def to_dict(self) -> Dict:
+        obj = super().to_dict()
+        return obj
+
 class HealAssemblyIntent(ExistingAssemblyIntent):
 
     def __init__(self, assembly_id: str = None, assembly_name: str = None, 

--- a/lmctl/client/models/intents.py
+++ b/lmctl/client/models/intents.py
@@ -94,31 +94,37 @@ class DeleteAssemblyIntent(ExistingAssemblyIntent):
         return (isinstance(other, DeleteAssemblyIntent) and self.assembly_name==other.assembly_name
             and self.assembly_id==other.assembly_id)
 
-class RetryAssemblyIntent(ExistingAssemblyIntent):
+class RetryAssemblyIntent():
 
-    def __init__(self, assembly_id: str = None):
-        super().__init__(assembly_id=assembly_id)
+    def __init__(self, process_id: str = None):
+        self.process_id = process_id
 
     def to_dict(self) -> Dict:
-        obj = super().to_dict()
+        obj = {}
+        if self.process_id is not None:
+            obj['process_id'] = self.process_id
         return obj
 
-class RollbackAssemblyIntent(ExistingAssemblyIntent):
+class RollbackAssemblyIntent():
 
-    def __init__(self, assembly_id: str = None):
-        super().__init__(assembly_id=assembly_id)
+    def __init__(self, process_id: str = None):
+        self.process_id = process_id
 
     def to_dict(self) -> Dict:
-        obj = super().to_dict()
+        obj = {}
+        if self.process_id is not None:
+            obj['process_id'] = self.process_id
         return obj
 
-class CancelAssemblyIntent(ExistingAssemblyIntent):
+class CancelAssemblyIntent():
 
-    def __init__(self, assembly_id: str = None):
-        super().__init__(assembly_id=assembly_id)
+    def __init__(self, process_id: str = None):
+        self.process_id = process_id
 
     def to_dict(self) -> Dict:
-        obj = super().to_dict()
+        obj = {}
+        if self.process_id is not None:
+            obj['process_id'] = self.process_id
         return obj
 
 class HealAssemblyIntent(ExistingAssemblyIntent):

--- a/tests/unit/cli/commands/test_cancel_retry_rollback.py
+++ b/tests/unit/cli/commands/test_cancel_retry_rollback.py
@@ -1,0 +1,47 @@
+import tests.unit.cli.commands.command_testing as command_testing
+import tempfile
+import os
+import shutil
+from unittest.mock import patch
+from lmctl.cli.controller import clear_global_controller
+from lmctl.cli.commands.login import login
+from lmctl.config import ConfigFinder, Config
+from lmctl.environment import EnvironmentGroup, TNCOEnvironment
+import lmctl.cli.commands.processes as process_cmds
+
+
+class TestIntentCommands(command_testing.CommandTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        clear_global_controller()
+
+        self.tnco_env_client_patcher = patch('lmctl.environment.lmenv.TNCOClientBuilder')
+        self.mock_tnco_client_builder_class = self.tnco_env_client_patcher.start()
+        self.addCleanup(self.tnco_env_client_patcher.stop)
+        self.mock_tnco_client_builder = self.mock_tnco_client_builder_class.return_value
+        self.mock_tnco_client = self.mock_tnco_client_builder.build.return_value
+        self.mock_tnco_client.get_access_token.return_value = '123'
+
+
+    def test_cancel_intent(self):
+        result = self.runner.invoke(process_cmds.cancel, ['process', '8475f402-cb6f-4ef1-a379-77c7e20cdf72'])
+        self.assert_no_errors(result)
+        expected_output = 'Accepted - Cancel request for process: 8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+        self.assert_output(result, expected_output)
+        self.mock_tnco_client.assemblies.intent_cancel.assert_called_once_with({'processId': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'})
+
+    def test_retry_intent(self):
+        result = self.runner.invoke(process_cmds.retry, ['process', '8475f402-cb6f-4ef1-a379-77c7e20cdf72'])
+        self.assert_no_errors(result)
+        expected_output = 'Accepted - Retry request for process: 8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+        self.assert_output(result, expected_output)
+        self.mock_tnco_client.assemblies.intent_retry.assert_called_once_with({'processId': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'})
+
+    def test_rollback_intent(self):
+        result = self.runner.invoke(process_cmds.rollback, ['process', '8475f402-cb6f-4ef1-a379-77c7e20cdf72'])
+        self.assert_no_errors(result)
+        expected_output = 'Accepted - Rollback request for process: 8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+        self.assert_output(result, expected_output)
+        self.mock_tnco_client.assemblies.intent_rollback.assert_called_once_with({'processId': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'})

--- a/tests/unit/cli/commands/test_cancel_retry_rollback.py
+++ b/tests/unit/cli/commands/test_cancel_retry_rollback.py
@@ -48,6 +48,14 @@ class TestIntentCommands(command_testing.CommandTestCase):
             }
         ), self.config_path)
 
+    def tearDown(self):
+        super().tearDown()
+
+        if os.path.exists(self.tmp_dir):
+            shutil.rmtree(self.tmp_dir)
+        if self.orig_lm_config is not None:
+            os.environ['LMCONFIG'] = self.orig_lm_config
+
     def test_cancel_intent(self):
         result = self.runner.invoke(process_cmds.cancel, ['process', '8475f402-cb6f-4ef1-a379-77c7e20cdf72'])
         self.assert_no_errors(result)

--- a/tests/unit/cli/commands/test_processes.py
+++ b/tests/unit/cli/commands/test_processes.py
@@ -10,7 +10,7 @@ from lmctl.environment import EnvironmentGroup, TNCOEnvironment
 import lmctl.cli.commands.processes as process_cmds
 
 
-class TestIntentCommands(command_testing.CommandTestCase):
+class TestProcessCommands(command_testing.CommandTestCase):
 
     def setUp(self):
         super().setUp()

--- a/tests/unit/client/api/test_assemblies.py
+++ b/tests/unit/client/api/test_assemblies.py
@@ -4,7 +4,8 @@ from unittest.mock import patch, MagicMock
 from lmctl.client.api import AssembliesAPI
 from lmctl.client.models import (CreateAssemblyIntent, UpgradeAssemblyIntent, ChangeAssemblyStateIntent, 
                                     DeleteAssemblyIntent, ScaleAssemblyIntent, HealAssemblyIntent,
-                                    AdoptAssemblyIntent, CreateOrUpgradeAssemblyIntent)
+                                    AdoptAssemblyIntent, CreateOrUpgradeAssemblyIntent, CancelAssemblyIntent,
+                                    RetryAssemblyIntent, RollbackAssemblyIntent)
 from lmctl.client.client_request import TNCOClientRequest
 
 class TestAssembliesAPI(unittest.TestCase):
@@ -238,3 +239,75 @@ class TestAssembliesAPI(unittest.TestCase):
         response = self.assemblies.intent_adopt(intent)
         self.assertEqual(response, '123')
         self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST', endpoint='api/intent/adoptAssembly', headers={'Content-Type': 'application/json'}, body=json.dumps(intent)))
+
+    def test_intent_cancel(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = CancelAssemblyIntent(process_id='8475f402-cb6f-4ef1-a379-77c7e20cdf72')
+        response = self.assemblies.intent_cancel(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/cancel',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))
+
+    def test_intent_cancel_with_dict(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = {'process_id' : '8475f402-cb6f-4ef1-a379-77c7e20cdf72'}
+        response = self.assemblies.intent_cancel(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/cancel',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))
+
+    def test_intent_retry(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = RetryAssemblyIntent(process_id='8475f402-cb6f-4ef1-a379-77c7e20cdf72')
+        response = self.assemblies.intent_retry(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/retry',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))
+
+    def test_intent_retry_with_dict(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = {'process_id' : '8475f402-cb6f-4ef1-a379-77c7e20cdf72'}
+        response = self.assemblies.intent_retry(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/retry',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))
+
+    def test_intent_rollback(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = RollbackAssemblyIntent(process_id='8475f402-cb6f-4ef1-a379-77c7e20cdf72')
+        response = self.assemblies.intent_rollback(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/rollback',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))
+
+    def test_intent_rollback_with_dict(self):
+        mock_response = MagicMock(status_code=200)
+        self.mock_client.make_request.return_value = mock_response
+        intent = {'process_id' : '8475f402-cb6f-4ef1-a379-77c7e20cdf72'}
+        response = self.assemblies.intent_rollback(intent)
+        self.mock_client.make_request.assert_called_with(TNCOClientRequest(method='POST',
+                                                        endpoint='api/intent/rollback',
+                                                        headers={'Content-Type': 'application/json'},
+                                                        body=json.dumps({
+                                                            'process_id': '8475f402-cb6f-4ef1-a379-77c7e20cdf72'
+                                                        })))


### PR DESCRIPTION
An intent process invoked by lmctl can subsequently be canceled, retried, or rolled back via the CP4NA GUI or its APIs. To support the rollback case, lmctl supports the processState, of the intent processes invoked by lmctl, being Rolling Back (as a transient state) or Rolled Back (as a terminal state).

cancel, retry or rollback can also be invoked using the following lmctl commands respectively, where the ID value is the processId value of the intent process.

lmctl cancel process [OPTIONS] ID
lmctl retry process [OPTIONS] ID
lmctl rollback process [OPTIONS] ID


`(env) maheshlokhande@maheshs-mbp LMCTL1 % lmctl cancel process 2ae2c2cf-cb5b-4d70-8004-3f8870f19684   
Accepted cancelling process : 2ae2c2cf-cb5b-4d70-8004-3f8870f19684`
`(env) maheshlokhande@maheshs-mbp LMCTL1 % lmctl retry process 2ae2c2cf-cb5b-4d70-8004-3f8870f19684     
Accepted retrying process : 2ae2c2cf-cb5b-4d70-8004-3f8870f19684
`

Signed-off-by: maheshlokhande1 <mahesh.lokhande@ibm.com>